### PR TITLE
THS-ST2 compliant rules

### DIFF
--- a/languagetool-language-modules/tl/src/main/java/org/languagetool/language/Tagalog.java
+++ b/languagetool-language-modules/tl/src/main/java/org/languagetool/language/Tagalog.java
@@ -86,16 +86,17 @@ public class Tagalog extends Language {
             new CommaWhitespaceRule(messages),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
-            new UppercaseSentenceStartRule(messages, this),
-            new MultipleWhitespaceRule(messages, this),
+            //new UppercaseSentenceStartRule(messages, this),
+            new MultipleWhitespaceRule(messages, this)
             // specific to Tagalog:
-            new MorfologikTagalogSpellerRule(messages, this, userConfig, altLanguages)
+            //new MorfologikTagalogSpellerRule(messages, this, userConfig, altLanguages)
     );
   }
 
   @Nullable
   @Override
   protected SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
-    return new MorfologikTagalogSpellerRule(messages, this, null, null);
+    return null;
+    //new MorfologikTagalogSpellerRule(messages, this, null, null);
   }
 }

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -152,7 +152,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 	<category id="CONSONANT_ALTERNATION" name="Pagpapalit ng D tungo sa R">
 		<rule id="KATINIG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
-			<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
+			<token regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
 				<token>rin</token>
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> din</suggestion>?</message>
@@ -163,7 +163,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 		</rule>
 		<rule id="PATINIG_DIN" name="Maling paggamit ng 'din' pagkatapos ng patinig o malapatinig">
 			<pattern case_sensitive="no">
-				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[aeiouwy]$</token>
+				<token regexp="yes">.*[aeiouwy]$</token>
 				<token>din</token>
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> rin</suggestion>?</message>
@@ -174,7 +174,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 		</rule>
 		<rule id="KATINIG_RAW" name="Maling paggamit ng 'raw' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
-				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
+				<token regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
 				<token>raw</token>
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> daw</suggestion>?</message>
@@ -185,7 +185,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 		</rule>
 		<rule id="PATINIG_DAW" name="Maling paggamit ng 'daw' pagkatapos ng patinig o malapatinig">
 			<pattern case_sensitive="no">
-				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[aeiouwy]$</token>
+				<token regexp="yes">.*[aeiouwy]$</token>
 				<token>daw</token>
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> raw</suggestion>?</message>
@@ -194,7 +194,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="umiyak raw" type="incorrect"><marker>umiyak daw</marker></example>
 			<example type="correct"><marker>kumain raw</marker></example>
 		</rule>
-		<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
+<!--	<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
 				<token>rin</token>
@@ -217,6 +217,10 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="araw raw" type="incorrect"><marker>araw raw</marker></example>
 			<example type="correct">maaari daw</example>
 			<example type="correct">araw daw</example>
-		</rule>
+		</rule> -->
 	</category>
+	<category id="PALITANG_E_I_AT_O_U" name="Palitang E/I at O/U">
+		<rule_id="PALITANG_E_I" name="Palitang E at I">
+			
+
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -24,91 +24,121 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 <rules lang="tl" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<category id="KASONG_KAMBAL_PATINIG" name="Kasong Kambal Patinig">
         <rule id="FIL_KAMBAL_PATINIG_BENEPISYO" name="Pangkalahatang Tuntunin: benepisyo">
-            <pattern case_sensitive="no"><token regexp="yes">\b(benepisio)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(benepisio)\b</token>
+			</pattern>
             <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'io' ay nagiging 'yo' sa salitang ito. Isaalang-alang ang <suggestion>benepisyo</suggestion>.</message>
             <short>Palitan ng 'yo' (benepisyo).</short>
-            <example correction="benepisyo">Malaki ang <marker>benepisio</marker> nitó.</example>
+            <example correction="benepisyo">Malaki ang <marker>benepisio</marker> nito.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_INDIBIDWAL" name="Pangkalahatang Tuntunin: indibidwal">
-            <pattern case_sensitive="no"><token regexp="yes">\b(indibidual)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(indibidual)\b</token>
+			</pattern>
             <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ua' ay nagiging 'wa' sa salitang ito. Isaalang-alang ang <suggestion>indibidwal</suggestion>.</message>
             <short>Palitan ng 'wa' (indibidwal).</short>
             <example correction="indibidwal">Isang <marker>indibidual</marker> ang lumapit.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_PERWISYO" name="Pangkalahatang Tuntunin: perwisyo">
-            <pattern case_sensitive="no"><token regexp="yes">\b(perwisio)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(perwisio)\b</token>
+			</pattern>
             <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'io' ay nagiging 'yo' sa salitang ito. Isaalang-alang ang <suggestion>perwisyo</suggestion>.</message>
             <short>Palitan ng 'yo' (perwisyo).</short>
             <example correction="perwisyo">Nagdulot ng <marker>perwisio</marker>.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_KOMPANYA" name="Pangkalahatang Tuntunin: kompanya">
-            <pattern case_sensitive="no"><token regexp="yes">\b(kompaniya|kompania)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(kompaniya|kompania)\b</token>
+			</pattern>
             <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ia' ay nagiging 'ya' sa salitang ito. Isaalang-alang ang <suggestion>kompanya</suggestion>.</message>
             <short>Palitan ng 'ya' (kompanya).</short>
             <example correction="kompanya">Ang <marker>kompania</marker> ay nagsara.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_TENYENTE" name="Pangkalahatang Tuntunin: tenyente">
-            <pattern case_sensitive="no"><token regexp="yes">\b(teniente)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(teniente)\b</token>
+			</pattern>
             <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ie' ay nagiging 'ye' sa salitang ito. Isaalang-alang ang <suggestion>tenyente</suggestion>.</message>
             <short>Palitan ng 'ye' (tenyente).</short>
             <example correction="tenyente">Si <marker>teniente</marker> ay dumating.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_KUWENTO" name="Kataliwasan 5.1: kuwento">
-            <pattern case_sensitive="no"><token regexp="yes">\b(kwento|kuento)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(kwento|kuento)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ue' sa unang pantig ay nagiging 'uwe'. Ang tamang baybay ay <suggestion>kuwento</suggestion>.</message>
             <short>Ang 'cuento' o 'kuento' ay dapat 'kuwento'.</short>
             <example correction="kuwento">Nagbasa siyá ng <marker>kuento</marker>.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_PUWERSA" name="Kataliwasan 5.1: puwersa">
-            <pattern case_sensitive="no"><token regexp="yes">\b(pwersa|puersa)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(pwersa|puersa)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ue' ay nagiging 'uwe' at ang 'f' ay nagiging 'p'. Ang tamang baybay ay <suggestion>puwersa</suggestion>.</message>
             <short>Ang 'fuerza' o 'puersa' ay dapat 'puwersa'.</short>
             <example correction="puwersa">Ginamit niya ang <marker>fuerza</marker>.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_PIYANO" name="Kataliwasan 5.1: piyano">
-            <pattern case_sensitive="no"><token regexp="yes">\b(piano|pyano)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(piano|pyano)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ia' sa unang pantig ay nagiging 'iya'. Ang tamang baybay ay <suggestion>piyano</suggestion>.</message>
             <short>Ang 'piano' ay dapat 'piyano'.</short>
             <example correction="piyano">Tumugtog siya ng <marker>piano</marker>.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_PIYESA" name="Kataliwasan 5.1: piyesa">
-            <pattern case_sensitive="no"><token regexp="yes">\b(pyesa|piesa)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(pyesa|piesa)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ie' ay nagiging 'iye' at ang 'z' ay nagiging 's'. Ang tamang baybay ay <suggestion>piyesa</suggestion>.</message>
             <short>Ang 'pieza' o 'piesa' ay dapat 'piyesa'.</short>
             <example correction="piyesa">Ito ang kulang na <marker>piesa</marker>.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_BIYUDA" name="Kataliwasan 5.1: biyuda">
-            <pattern case_sensitive="no"><token regexp="yes">\b(byuda|biuda)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(byuda|biuda)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'iu' ay nagiging 'iyu' at ang 'v' ay nagiging 'b'. Ang tamang baybay ay <suggestion>biyuda</suggestion>.</message>
             <short>Ang 'viuda' o 'biuda' ay dapat 'biyuda'.</short>
             <example correction="biyuda">Isang <marker>biuda</marker> si Aling Nena.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_LEKSIYON" name="Kataliwasan 5.2: leksiyon">
-            <pattern case_sensitive="no"><token regexp="yes">\b(leksyon|leksion)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(leksyon|leksion)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>leksiyon</suggestion>.</message>
             <short>Panatilihin ang patinig (leksiyon).</short>
             <example correction="leksiyon">Tapos na ang <marker>leksyon</marker>.</example>
         </rule>
 		<rule id="FIL_KAMBAL_PATINIG_KONTROBERSIYA" name="Kataliwasan 5.2: kontrobersiya">
-			<pattern case_sensitive="no"><token regexp="yes">\b(kontrobersia|kontrobersya|kuntrobersya)\b</token></pattern>
+			<pattern case_sensitive="no">
+				<token regexp="yes">\b(kontrobersia|kontrobersya|kuntrobersya)\b</token>
+			</pattern>
 			<message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>kontrobersiya</suggestion>.</message>
 			<short>Panatilihin ang patinig (kontrobersiya).</short>
 			<example correction="kontrobersiya">Maraming <marker>controbersia</marker> tungkol dito.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_LENGGUWAHE" name="Kataliwasan 5.2: lengguwahe">
-            <pattern case_sensitive="no"><token regexp="yes">\b(lenggwahe)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(lenggwahe)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>lengguwahe</suggestion>.</message>
             <short>Panatilihin ang patinig (lengguwahe).</short>
             <example correction="lengguwahe">Iba ang <marker>lenggwahe</marker> nila.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_KOLEHIYO" name="Kataliwasan 5.3: kolehiyo">
-            <pattern case_sensitive="no"><token regexp="yes">\b(kolehyo|kolehio)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(kolehyo|kolehio)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.3), kapag ang kambal-patinig ay sumusunod sa 'h', pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>kolehiyo</suggestion>.</message>
             <short>Panatilihin ang patinig (kolehiyo).</short>
             <example correction="kolehiyo">Nasa <marker>kolehyo</marker> na siya.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_REHIYON" name="Kataliwasan 5.3: rehiyon">
-            <pattern case_sensitive="no"><token regexp="yes">\b(rehyon|rehion)\b</token></pattern>
+            <pattern case_sensitive="no">
+				<token regexp="yes">\b(rehyon|rehion)\b</token>
+			</pattern>
             <message>Ayon sa KWF Manwal (5.3), kapag ang kambal-patinig ay sumusunod sa 'h', pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>rehiyon</suggestion>.</message>
             <short>Panatilihin ang patinig (rehiyon).</short>
             <example correction="rehiyon">Saang <marker>rehyon</marker> iyon?</example>
@@ -201,6 +231,19 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="pag ibig" type="incorrect"><marker>pag ibig</marker></example>
 			<example correction="mag aral" type="incorrect"><marker>mag aral</marker></example>
 			<example correction="nag iisa" type="incorrect"><marker>nag iisa</marker></example>
+			<example type="correct"><marker>pag-ibig</marker></example>
+			<example type="correct"><marker>mag-aral</marker></example>
+			<example type="correct"><marker>nag-iisa</marker></example>
+		</rule>
+		<rule id="PAGHIHIWALAY_NG_KATINIG_SA_PATINIG_NOSPACE" name="Paghiwalay ng katinig sa patinig (walang espasyo)">
+			<pattern case_sensitive="no">
+				<token regexp="yes">^(pag|mag|nag|pang)([aeiou].*)$</token>
+			</pattern>
+			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1" regexp_match="^(pag|mag|nag|pang)([aeiou].*)$" regexp_replace="$1-$2"/></suggestion>.</message>
+			<short>Gamitin ang gitling sa salita.</short>
+			<example correction="pag-ibig" type="incorrect"><marker>pagibig</marker></example>
+			<example correction="mag-aral" type="incorrect"><marker>magaral</marker></example>
+			<example correction="nag-iisa" type="incorrect"><marker>nagiisa</marker></example>
 			<example type="correct"><marker>pag-ibig</marker></example>
 			<example type="correct"><marker>mag-aral</marker></example>
 			<example type="correct"><marker>nag-iisa</marker></example>
@@ -333,7 +376,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 				<token>ala</token>
 				<token>una</token>
 			</pattern>
-			<message>Tandaan: Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
+			<message>Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
 			<suggestion>ala-una</suggestion>
 			<short>Laging 'ala-una' ang baybay.</short>
 			<example correction="ala-una" type="incorrect">ala una</example>
@@ -361,14 +404,41 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>'yan</marker></example>
 			<example type="correct"><marker>'yon</marker></example>
 		</rule>
-		<rule id="MADALAS_NA_MGA_PINAPAIKLI" name="Mga salitang pinaikli">
+		<rule id="HINDI_DAPAT_PAGDIKITIN_KAMO" name="Hindi dapat pagdikitin ('ka mo)">
 			<pattern case_sensitive="no">
-				<token regexp="yes">sya|nya</token>
+				<token regexp="yes">kamo</token>
 			</pattern>
-			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(s|n)(ya)$" regexp_replace="$1'ya"/></suggestion>?</message>
-			<short>Gamitin ang kudlit sa s'ya.</short>
-			<example correction="sya" type="incorrect">sya</example>
-			<example type="correct">s'ya</example>
+			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(ka)(mo)$" regexp_replace="'$1 mo"/></suggestion>?</message>
+			<short>Dapat may kudlit sa 'ka' at 'mo'.</short>
+			<example correction="kamo" type="incorrect">kamo</example>
+			<example type="correct">'ka mo</example>
+		</rule>
+		<rule id="HINDI_DAPAT_PAGDIKITIN_SAYO" name="Hindi dapat pagdikitin (sa 'yo)">
+			<pattern case_sensitive="no">
+				<token regexp="yes">sayo</token>
+			</pattern>
+			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(sa)(yo)$" regexp_replace="$1 'yo"/></suggestion>?</message>
+			<short>Dapat may kudlit ang 'yo sa 'sa 'yo'.</short>
+			<example correction="sayo" type="incorrect">sayo</example>
+			<example type="correct">sa 'yo</example>
+		</rule>
+		<rule id="HINDI_DAPAT_PAGDIKITIN_NARON" name="Hindi dapat pagdikitin (nar'on)">
+			<pattern case_sensitive="no">
+				<token regexp="yes">naron</token>
+			</pattern>
+			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(nar)(on)$" regexp_replace="$1'on"/></suggestion>?</message>
+			<short>Dapat may kudlit ang 'on' sa 'nar'on'.</short>
+			<example correction="naron" type="incorrect">naron</example>
+			<example type="correct">nar'on</example>
+		</rule>
+		<rule id="HINDI_DAPAT_PAGDIKITIN_ANONG" name="Hindi dapat pagdikitin (ano'ng)">
+			<pattern case_sensitive="no">
+				<token regexp="yes">anong</token>
+			</pattern>
+			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(ano)(ng)$" regexp_replace="$1'ng"/></suggestion>?</message>
+			<short>Dapat may kudlit ang 'ng' sa 'ano'ng'.</short>
+			<example correction="anong" type="incorrect">anong</example>
+			<example type="correct">ano'ng</example>
 		</rule>
 	</category>
 	<category id="PALITANG E/I AT O/U" name="Palitang E/I at O/U">
@@ -410,7 +480,10 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example type="correct">kompanya</example>
         </rule>
         <rule id="KAPAG_NAGBAGO_ANG_KATINIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso)">
-            <pattern case_sensitive="no">
+            <antipattern>
+				<token regexp="yes">(?i)(kuntrobersya)</token>
+			</antipattern>
+			<pattern case_sensitive="no">
                 <token regexp="yes">[km]un(?!p|b|f|v).*</token>
             </pattern>
             <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^([km])(un)(.*)$" regexp_replace="$1on$3"/></suggestion>?</message>
@@ -431,7 +504,10 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example type="correct">kababaihan</example>
         </rule>
         <rule id="EPEKTO_NG_HULAPI_O_TO_U" name="Pagpalit ng O sa U (Epekto ng Hulapi)">
-            <pattern case_sensitive="no">
+            <antipattern>
+                <token regexp="yes">(?i)(kabuoan|buorin|pagtuonan|tuosin|kasalimuotan|panoorin|paroonan|kapootan|kanoonan)</token>
+            </antipattern>
+			<pattern case_sensitive="no">
                 <token regexp="yes">.*o(han|hin|in|an)$</token>
             </pattern>
             <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(.*)o(han|hin|in|an)$" regexp_replace="$1u$2"/></suggestion>?</message>
@@ -441,5 +517,58 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="takbuhan" type="incorrect">takbohan</example>
             <example type="correct">biruin</example>
         </rule>
+		<rule id="KAILAN_DI_NAGPAPALIT_E_AT_I" name="Huwag Palitan ang E sa I (Pag-uulit)">
+			<pattern case_sensitive="no">
+				<token>babaing</token>
+				<token>-</token>
+				<token>babae</token>
+			</pattern>
+			<message>Hindi ang "babaing-babae." Isaalang-alang ang <suggestion>babaeng-babae</suggestion>.</message>
+			<short>Panatilihin ang 'e' sa babaeng-babae.</short>
+			<example correction="babaeng-babae">Isang <marker>babaing</marker><marker>-</marker><marker>babae</marker> si Maria.</example>
+			<example type="correct">babaeng-babae</example>
+		</rule>
+		<rule id="KAILAN_DI_NAGPAPALIT_O_AT_U" name="Huwag Palitan ang O sa U (Pag-uulit)">
+			<pattern case_sensitive="no">
+				<token regexp="yes">\b(anu|alun|taun|pisu|pitu|patung|biru|palung)\b</token>
+				<token>-</token>
+				<token regexp="yes">\b(ano|alon|taon|piso|pito|patong|biro|palungan)\b</token>
+			</pattern>
+			<message>Hindi kailangang baguhin ang 'o' sa 'u' kapag inuulit ang salitang-ugat. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w+)u$" regexp_replace="$1o"/>-<match no="3"/></suggestion>.</message>
+			<short>Panatilihin ang 'o' sa salitang inuulit.</short>
+			<example correction="ano-ano">Nagdala siya ng <marker>anu</marker><marker>-</marker><marker>ano</marker>.</example>
+			<example correction="alon-alon">Ang buhok niya ay <marker>alun</marker><marker>-</marker><marker>alon</marker>.</example>
+			<example correction="taon-taon">Ginagawa ito <marker>taun</marker><marker>-</marker><marker>taon</marker>.</example>
+			<example correction="piso-piso">Barya na lamang na <marker>pisu</marker><marker>-</marker><marker>piso</marker>.</example>
+			<example correction="biro-biro">Ito ay <marker>biru</marker><marker>-</marker><marker>biro</marker> lámang.</example>
+			<example correction="palong-palungan">Ang <marker>palung</marker><marker>-</marker><marker>palungan</marker> ng manok.</example>
+			<example type="correct">ano-ano</example>
+			<example type="correct">biro-biro</example>
+		</rule>
+		<rule id="FIL_UO_HULAPI" name="Pagpapanatili ng 'uo'">
+			<pattern case_sensitive="no">
+				<token regexp="yes">\b(kabuuan|buurin|pagtuunan|tuusin|kasalimuutan)\b</token>
+			</pattern>
+			<message>Ayon sa KWF Manwal (7.7), ang kambal-patinig na 'uo' ay karaniwang hindi nagbabago kapag hinuhulapian. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w*)uu(\w*)$" regexp_replace="$1uo$2"/></suggestion>.</message>
+			<short>Huwag palitan ang 'uo' ng 'uu'.</short>
+			<example correction="kabuoan">Ang <marker>kabuuan</marker> ng kuwento.</example>
+			<example correction="buorin">Subukang <marker>buurin</marker> ang teksto.</example>
+			<example correction="pagtuonan">Dapat <marker>pagtuunan</marker> ng pansin.</example>
+			<example correction="tuosin">Kailangang <marker>tuusin</marker> ang gastos.</example>
+			<example correction="kasalimuotan">Ang <marker>kasalimuutan</marker> ng problèma.</example>
+			<example type="correct">kabuoan</example>
+		</rule>
+		<rule id="FIL_OO_HULAPI" name="Pagpapanatili ng 'oo'">
+			<pattern case_sensitive="no">
+				<token regexp="yes">\b(panuorin|paruonan|kapuotan|kanuonan)\b</token>
+			</pattern>
+			<message>Ayon sa KWF Manwal (7.7), ang dobleng 'oo' ay karaniwang hindi nagbabago kapag hinuhulapian. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w*)uo(\w*)$" regexp_replace="$1oo$2"/></suggestion>.</message>
+			<short>Huwag palitan ang 'oo' ng 'uu' (hal. panoorin).</short>
+			<example correction="panoorin">Gusto kong <marker>panuorin</marker> iyon.</example>
+			<example correction="paroonan">Ang <marker>paruonan</marker> nila.</example>
+			<example correction="kapootan">Puno ng <marker>kapuotan</marker>.</example>
+			<example correction="kanoonan">Sa <marker>kanuonan</marker> pa.</example>
+			<example type="correct">panoorin</example>
+		</rule>
 	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -545,7 +545,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct">ano-ano</example>
 			<example type="correct">biro-biro</example>
 		</rule>
-		<rule id="FIL_UO_HULAPI" name="Pagpapanatili ng 'uo'">
+		<rule id="HUWAG_BAGUHIN_ANG_DOBLENG_OO_OU" name="Pagpapanatili ng 'uo'">
 			<pattern case_sensitive="no">
 				<token regexp="yes">\b(kabuuan|buurin|pagtuunan|tuusin|kasalimuutan)\b</token>
 			</pattern>
@@ -558,7 +558,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="kasalimuotan">Ang <marker>kasalimuutan</marker> ng problèma.</example>
 			<example type="correct">kabuoan</example>
 		</rule>
-		<rule id="FIL_OO_HULAPI" name="Pagpapanatili ng 'oo'">
+		<rule id="HUWAG_BAGUHIN_ANG_DOBLENG_OO" name="Pagpapanatili ng 'oo'">
 			<pattern case_sensitive="no">
 				<token regexp="yes">\b(panuorin|paruonan|kapuotan|kanuonan)\b</token>
 			</pattern>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -215,8 +215,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<short>Gamitin ang "daw" imbes na "raw".</short>
 			<example correction="maaari raw" type="incorrect"><marker>maaari raw</marker></example>
 			<example correction="araw raw" type="incorrect"><marker>araw raw</marker></example>
-			<example type="correct">maaari din</example>
-			<example type="correct">araw din</example>
+			<example type="correct">maaari daw</example>
+			<example type="correct">araw daw</example>
 		</rule>
 	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -22,6 +22,98 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 See tagset.txt for the different POS, Lexical Categories, and corresponding attributes
 -->
 <rules lang="tl" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<category id="KASONG_KAMBAL_PATINIG" name="Kasong Kambal Patinig">
+        <rule id="FIL_KAMBAL_PATINIG_BENEPISYO" name="Pangkalahatang Tuntunin: benepisyo">
+            <pattern case_sensitive="no"><token regexp="yes">\b(benepisio)\b</token></pattern>
+            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'io' ay nagiging 'yo' sa salitang ito. Isaalang-alang ang <suggestion>benepisyo</suggestion>.</message>
+            <short>Palitan ng 'yo' (benepisyo).</short>
+            <example correction="benepisyo">Malaki ang <marker>benepisio</marker> nitó.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_INDIBIDWAL" name="Pangkalahatang Tuntunin: indibidwal">
+            <pattern case_sensitive="no"><token regexp="yes">\b(indibidual)\b</token></pattern>
+            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ua' ay nagiging 'wa' sa salitang ito. Isaalang-alang ang <suggestion>indibidwal</suggestion>.</message>
+            <short>Palitan ng 'wa' (indibidwal).</short>
+            <example correction="indibidwal">Isang <marker>indibidual</marker> ang lumapit.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_PERWISYO" name="Pangkalahatang Tuntunin: perwisyo">
+            <pattern case_sensitive="no"><token regexp="yes">\b(perwisio)\b</token></pattern>
+            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'io' ay nagiging 'yo' sa salitang ito. Isaalang-alang ang <suggestion>perwisyo</suggestion>.</message>
+            <short>Palitan ng 'yo' (perwisyo).</short>
+            <example correction="perwisyo">Nagdulot ng <marker>perwisio</marker>.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_KOMPANYA" name="Pangkalahatang Tuntunin: kompanya">
+            <pattern case_sensitive="no"><token regexp="yes">\b(kompaniya|kompania)\b</token></pattern>
+            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ia' ay nagiging 'ya' sa salitang ito. Isaalang-alang ang <suggestion>kompanya</suggestion>.</message>
+            <short>Palitan ng 'ya' (kompanya).</short>
+            <example correction="kompanya">Ang <marker>kompania</marker> ay nagsara.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_TENYENTE" name="Pangkalahatang Tuntunin: tenyente">
+            <pattern case_sensitive="no"><token regexp="yes">\b(teniente)\b</token></pattern>
+            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ie' ay nagiging 'ye' sa salitang ito. Isaalang-alang ang <suggestion>tenyente</suggestion>.</message>
+            <short>Palitan ng 'ye' (tenyente).</short>
+            <example correction="tenyente">Si <marker>teniente</marker> ay dumating.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_KUWENTO" name="Kataliwasan 5.1: kuwento">
+            <pattern case_sensitive="no"><token regexp="yes">\b(kwento|kuento)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ue' sa unang pantig ay nagiging 'uwe'. Ang tamang baybay ay <suggestion>kuwento</suggestion>.</message>
+            <short>Ang 'cuento' o 'kuento' ay dapat 'kuwento'.</short>
+            <example correction="kuwento">Nagbasa siyá ng <marker>kuento</marker>.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_PUWERSA" name="Kataliwasan 5.1: puwersa">
+            <pattern case_sensitive="no"><token regexp="yes">\b(pwersa|puersa)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ue' ay nagiging 'uwe' at ang 'f' ay nagiging 'p'. Ang tamang baybay ay <suggestion>puwersa</suggestion>.</message>
+            <short>Ang 'fuerza' o 'puersa' ay dapat 'puwersa'.</short>
+            <example correction="puwersa">Ginamit niya ang <marker>fuerza</marker>.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_PIYANO" name="Kataliwasan 5.1: piyano">
+            <pattern case_sensitive="no"><token regexp="yes">\b(piano|pyano)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ia' sa unang pantig ay nagiging 'iya'. Ang tamang baybay ay <suggestion>piyano</suggestion>.</message>
+            <short>Ang 'piano' ay dapat 'piyano'.</short>
+            <example correction="piyano">Tumugtog siya ng <marker>piano</marker>.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_PIYESA" name="Kataliwasan 5.1: piyesa">
+            <pattern case_sensitive="no"><token regexp="yes">\b(pyesa|piesa)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ie' ay nagiging 'iye' at ang 'z' ay nagiging 's'. Ang tamang baybay ay <suggestion>piyesa</suggestion>.</message>
+            <short>Ang 'pieza' o 'piesa' ay dapat 'piyesa'.</short>
+            <example correction="piyesa">Ito ang kulang na <marker>piesa</marker>.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_BIYUDA" name="Kataliwasan 5.1: biyuda">
+            <pattern case_sensitive="no"><token regexp="yes">\b(byuda|biuda)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'iu' ay nagiging 'iyu' at ang 'v' ay nagiging 'b'. Ang tamang baybay ay <suggestion>biyuda</suggestion>.</message>
+            <short>Ang 'viuda' o 'biuda' ay dapat 'biyuda'.</short>
+            <example correction="biyuda">Isang <marker>biuda</marker> si Aling Nena.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_LEKSIYON" name="Kataliwasan 5.2: leksiyon">
+            <pattern case_sensitive="no"><token regexp="yes">\b(leksyon|leksion)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>leksiyon</suggestion>.</message>
+            <short>Panatilihin ang patinig (leksiyon).</short>
+            <example correction="leksiyon">Tapos na ang <marker>leksyon</marker>.</example>
+        </rule>
+		<rule id="FIL_KAMBAL_PATINIG_KONTROBERSIYA" name="Kataliwasan 5.2: kontrobersiya">
+			<pattern case_sensitive="no"><token regexp="yes">\b(kontrobersia|kontrobersya|kuntrobersya)\b</token></pattern>
+			<message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>kontrobersiya</suggestion>.</message>
+			<short>Panatilihin ang patinig (kontrobersiya).</short>
+			<example correction="kontrobersiya">Maraming <marker>controbersia</marker> tungkol dito.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_LENGGUWAHE" name="Kataliwasan 5.2: lengguwahe">
+            <pattern case_sensitive="no"><token regexp="yes">\b(lenggwahe)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>lengguwahe</suggestion>.</message>
+            <short>Panatilihin ang patinig (lengguwahe).</short>
+            <example correction="lengguwahe">Iba ang <marker>lenggwahe</marker> nila.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_KOLEHIYO" name="Kataliwasan 5.3: kolehiyo">
+            <pattern case_sensitive="no"><token regexp="yes">\b(kolehyo|kolehio)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.3), kapag ang kambal-patinig ay sumusunod sa 'h', pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>kolehiyo</suggestion>.</message>
+            <short>Panatilihin ang patinig (kolehiyo).</short>
+            <example correction="kolehiyo">Nasa <marker>kolehyo</marker> na siya.</example>
+        </rule>
+        <rule id="FIL_KAMBAL_PATINIG_REHIYON" name="Kataliwasan 5.3: rehiyon">
+            <pattern case_sensitive="no"><token regexp="yes">\b(rehyon|rehion)\b</token></pattern>
+            <message>Ayon sa KWF Manwal (5.3), kapag ang kambal-patinig ay sumusunod sa 'h', pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>rehiyon</suggestion>.</message>
+            <short>Panatilihin ang patinig (rehiyon).</short>
+            <example correction="rehiyon">Saang <marker>rehyon</marker> iyon?</example>
+        </rule>
+	</category>
 	<category id="PAGPAPALIT_D_TUNGO_SA_R" name="Pagpapalit ng D tungo sa R">
 		<rule id="KASONG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
@@ -247,6 +339,15 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="ala-una" type="incorrect">ala una</example>
 			<example type="correct">ala-una</example>
 		</rule>
+		<rule id="WALANG_GITLING_SA_IBA_T_IBA" name="Walang gitling sa iba't iba">
+			<pattern case_sensitive="no">
+				<token regexp="yes">iba't-iba</token>
+			</pattern>
+			<message>Ang wastong baybay ay <suggestion>iba't iba</suggestion> (walang gitling).</message>
+			<short>Walang gitling sa pagitan ng iba't iba.</short>
+			<example correction="iba't iba" type="incorrect"><marker>iba't-iba</marker></example>
+			<example type="correct"><marker>iba't iba</marker></example>
+		</rule>
 	</category>
 	<category id="WASTONG_PAGGAMIT_NG_KUDLIT" name="Pagpapaikli ng mga Salita">
 		<rule id="KUDLIT_YAN_YON" name="Paggamit ng kudlit sa yan/yon">
@@ -271,7 +372,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 		</rule>
 	</category>
 	<category id="PALITANG E/I AT O/U" name="Palitang E/I at O/U">
-		<rule id="KAPAG_NAGBAGO_ANG_PANTIG_KUMP" name="Palitang O/U (con/kon/kom -> kump)">
+		<rule id="KAPAG_NAGBAGO_ANG_KATINIG_KUMP" name="Palitang O/U (con/kon/kom -> kump)">
 			<antipattern>
 				<token regexp="yes">(?i)(kompanya|kompleto|kompetisyon|kompromiso|kompanyon)</token>
 			</antipattern>
@@ -286,7 +387,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct" anti_example="yes">kompanya</example>
 			<example type="correct" anti_example="yes">kompleto</example>
 		</rule>
-		<rule id="KAPAG_NAGBAGO_ANG_PANTIG_KUMB" name="Palitang O/U (con/kon/kom -> kumb)">
+		<rule id="KAPAG_NAGBAGO_ANG_KATINIG_KUMB" name="Palitang O/U (con/kon/kom -> kumb)">
 			<antipattern>
 				<token regexp="yes">(?i)(kombinasyon|kombat)</token>
 			</antipattern>
@@ -298,7 +399,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="kombensiyon" type="incorrect">kombensiyon</example>
 			<example type="correct">kumbensiyon</example>
 		</rule>
-        <rule id="KAPAG_NAGBAGO_ANG_PANTIG_ESPANYOL_EKSEPSIYON" name="Palitang O/U (mga eksepsiyon, kum -> kom)">
+        <rule id="KAPAG_NAGBAGO_ANG_KATINIG_ESPANYOL_EKSEPSIYON" name="Palitang O/U (mga eksepsiyon, kum -> kom)">
             <pattern case_sensitive="no">
                 <token regexp="yes">kum(panya|pleto|petisyon|binasyon)</token>
             </pattern>
@@ -308,12 +409,12 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="kumpleto" type="incorrect">kumpleto</example>
             <example type="correct">kompanya</example>
         </rule>
-        <rule id="KAPAG_NAGBAGO_ANG_PANTIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso)">
+        <rule id="KAPAG_NAGBAGO_ANG_KATINIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso)">
             <pattern case_sensitive="no">
                 <token regexp="yes">[km]un(?!p|b|f|v).*</token>
             </pattern>
             <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^([km])(un)(.*)$" regexp_replace="$1on$3"/></suggestion>?</message>
-            <short>Dapat manatili ang 'o' sa salitang ito.</short>
+            <short>Dapat manatili ang 'o' sa salitang ito kung 'N' ang kasunod sa orihinal na salita.</short>
             <example correction="kuntrata" type="incorrect">kuntrata</example>
             <example correction="munumento" type="incorrect">munumento</example>
             <example type="correct">kontrata</example>
@@ -333,7 +434,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
                 <token regexp="yes">.*o(han|hin|in|an)$</token>
             </pattern>
-            <message>Ibig mo bang sabihin<suggestion><match no="1" regexp_match="^(.*)o(han|hin|in|an)$" regexp_replace="$1u$2"/></suggestion>?</message>
+            <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(.*)o(han|hin|in|an)$" regexp_replace="$1u$2"/></suggestion>?</message>
             <short>Palitan ang 'o' ng 'u' kapag may hulapi.</short>
             <example correction="biroin" type="incorrect">biroin</example>
             <example correction="kalbuhin" type="incorrect">kalbohin</example>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -549,7 +549,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<pattern case_sensitive="no">
 				<token regexp="yes">\b(kabuuan|buurin|pagtuunan|tuusin|kasalimuutan)\b</token>
 			</pattern>
-			<message>Ayon sa KWF Manwal (7.7), ang kambal-patinig na 'uo' ay karaniwang hindi nagbabago kapag hinuhulapian. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w*)uu(\w*)$" regexp_replace="$1uo$2"/></suggestion>.</message>
+			<message>Ang kambal-patinig na 'uo' ay karaniwang hindi nagbabago kapag hinuhulapian. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w*)uu(\w*)$" regexp_replace="$1uo$2"/></suggestion>.</message>
 			<short>Huwag palitan ang 'uo' ng 'uu'.</short>
 			<example correction="kabuoan">Ang <marker>kabuuan</marker> ng kuwento.</example>
 			<example correction="buorin">Subukang <marker>buurin</marker> ang teksto.</example>
@@ -562,8 +562,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<pattern case_sensitive="no">
 				<token regexp="yes">\b(panuorin|paruonan|kapuotan|kanuonan)\b</token>
 			</pattern>
-			<message>Ayon sa KWF Manwal (7.7), ang dobleng 'oo' ay karaniwang hindi nagbabago kapag hinuhulapian. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w*)uo(\w*)$" regexp_replace="$1oo$2"/></suggestion>.</message>
-			<short>Huwag palitan ang 'oo' ng 'uu' (hal. panoorin).</short>
+			<message>Ang dobleng 'oo' ay karaniwang hindi nagbabago kapag hinuhulapian. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w*)uo(\w*)$" regexp_replace="$1oo$2"/></suggestion>.</message>
+			<short>Huwag palitan ang 'oo' ng 'uo'.</short>
 			<example correction="panoorin">Gusto kong <marker>panuorin</marker> iyon.</example>
 			<example correction="paroonan">Ang <marker>paruonan</marker> nila.</example>
 			<example correction="kapootan">Puno ng <marker>kapuotan</marker>.</example>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -146,6 +146,28 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct">araw-araw</example>
 			<example type="correct">paruparo</example> 
 		</rule>
+		<rule id="INUULIT_NA_SALITA_MAHIGIT_DALAWANG_PANTIG" name="Paggamit ng gitling sa inuulit na salita (pinagdikit)">
+			<pattern case_sensitive="no">
+				<token regexp="yes">(palipalito|balubaluktot|balibaligtad|bulabulagsak)</token>
+			</pattern>
+			<message>Ginagamit ang gitling (-) sa mga salitang inuulit. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(pali)(palito)$" regexp_replace="$1-$2"/></suggestion><suggestion><match no="1" regexp_match="^(balu)(baluktot)$" regexp_replace="$1-$2"/></suggestion><suggestion><match no="1" regexp_match="^(bali)(baligtad)$" regexp_replace="$1-$2"/></suggestion><suggestion><match no="1" regexp_match="^(bula)(bulagsak)$" regexp_replace="$1-$2"/></suggestion>.</message>
+			<short>Lagyan ng gitling ang inuulit na salita.</short>
+			<example correction="pali-palito">palipalito</example>
+			<example correction="balu-baluktot">balubaluktot</example>
+			<example correction="bali-baligtad">balibaligtad</example>
+			<example type="correct">pali-palito</example>
+		</rule>
+		<rule id="INUULIT_NA_SALITA_MAHIGIT_DALAWANG_PANTIG_SPACE" name="Paggamit ng gitling sa inuulit na salita (may espasyo)">
+			<pattern>
+				<token regexp="yes">(?i)(pali|balu|bali|bula)</token>
+				<token regexp="yes">(?i)(palito|baluktot|baligtad|bulagsak)</token>
+			</pattern>
+			<message>Ginagamit ang gitling (-) sa mga salitang inuulit. Isaalang-alang ang <suggestion><match no="1"/>-<match no="2"/></suggestion>.</message>
+			<short>Lagyan ng gitling ang inuulit na salita.</short>
+			<example correction="pali-palito">pali palito</example>
+			<example correction="balu-baluktot">balu baluktot</example>
+			<example type="correct">pali-palito</example>
+		</rule>
 		<rule id="PASULAT_NA_ORAS_IKA" name="Paggamit ng gitling sa 'ika-' na sinusundan ng numero">
             <pattern case_sensitive="no">
                 <token regexp="yes">ika(\d+)</token>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -22,133 +22,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 See tagset.txt for the different POS, Lexical Categories, and corresponding attributes
 -->
 <rules lang="tl" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <category id="PROPER_ALA_ALAS_USAGE" name="Wastong Paggamit ng 'Ala' at 'Alas'">
-        <rule id="ALA_MISSING_GITLING" name="Gitling sa 'ala-una'">
-			<pattern case_sensitive="no">
-				<token>ala</token>
-				<token regexp="yes">una</token>
-			</pattern>
-			<message>Nais mo bang gumamit ng gitling? Gamitin ang <suggestion>ala-una</suggestion>.</message>
-			<short>Gumamit ng gitling sa pagitan ng "ala" at "una". Ang "ala" ay para lamang sa "ala-una".</short>
-			<example correction="ala-una" type="incorrect"><marker>ala una</marker></example>
-			<example correction="ala-1" type="incorrect"><marker>ala 1</marker></example>
-			<example type="correct"><marker>ala-una</marker></example>
-		</rule>
-        <rule id="ALAS_MISSING_GITLING" name="Gitling sa 'alas-(dos->dose)'">
-            <pattern case_sensitive="no">
-                <token>alas</token>
-                <token regexp="yes">(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
-            </pattern>
-            <message>Nais mo bang gumamit ng gitling? Gamitin ang <suggestion>alas-\2</suggestion>.</message>
-            <short>Maglagay ng gitling sa pagitan ng "alas" at oras mula 2-12.</short>
-            <example correction="alas-dos" type="incorrect"><marker>alas dos</marker></example>
-			<example correction="alas-2" type="incorrect"><marker>alas 2</marker></example>
-			<example type="correct"><marker>alas-dos</marker></example>
-			<example type="correct"><marker>alas-2</marker></example>
-        </rule>
-		<rule id="ALA_INCORRECT_USAGE_NUMERIC" name="Maling paggamit ng 'ala' (ala-1)">
-			<pattern case_sensitive="no">
-				<token>ala</token>
-				<token>-</token>
-				<token regexp="yes">1</token>
-			</pattern>
-  			<message>Nais mo bang gamitin ang <suggestion>ala-una</suggestion>?</message>
-			<short>Gamitin ang ala-una sa halip na ala-1.</short>
-			<example correction="ala-una" type="incorrect"><marker>ala-1</marker></example>
-			<example type="correct"><marker>ala-una</marker></example>
-		</rule>
-		<rule id="ALA_INCORRECT_USAGE" name="Maling paggamit ng 'ala' (ala-(dos->dose))">
-			<pattern case_sensitive="no">
-				<token>ala</token>
-				<token>-</token>
-                <token regexp="yes">(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
-			</pattern>
-  			<message>Nais mo bang gamitin ang <suggestion>alas-\3</suggestion>?</message>
-			<short>Gamitin ang alas-(2-12 / dos-dose) imbes na ala-(2-12 / dos-dose).</short>
-			<example correction="alas-dos" type="incorrect"><marker>ala-dos</marker></example>
-			<example correction="alas-2" type="incorrect"><marker>ala-2</marker></example>
-			<example type="correct"><marker>alas-dos</marker></example>
-			<example type="correct"><marker>alas-2</marker></example>
-		</rule>
-		<rule id="ALAS_INCORRECT_USAGE" name="Maling paggamit ng 'alas' (alas-una)">
-			<pattern case_sensitive="no">
-				<token>alas</token>
-				<token>-</token>
-				<token regexp="yes">una|1</token>
-			</pattern>
-  			<message>Did you mean to use <suggestion>ala-una</suggestion>?</message>
-			<short>Use ala-una instead of alas-una.</short>
-			<example correction="ala-una" type="incorrect"><marker>alas-una</marker></example>
-			<example correction="ala-1" type="incorrect"><marker>alas-1</marker></example>
-			<example type="correct"><marker>ala-una</marker></example>
-		</rule>
-		<rule id="ALA_INCORRECT_USAGE_NO_GITLING" name="Maling paggamit ng 'ala' (ala (dos->dose))">
-			<pattern case_sensitive="no">
-				<token>ala</token>
-				<token regexp="yes">(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
-			</pattern>
-  			<message>Nais mo bang gamitin ang <suggestion>alas-\2</suggestion>?</message>
-			<short>Gamitin ang alas-(2-12 / dos-dose) imbes na ala-(2-12 / dos-dose).</short>
-			<example correction="alas-dos" type="incorrect"><marker>ala dos</marker></example>
-			<example correction="alas-2" type="incorrect"><marker>ala 2</marker></example>
-			<example type="correct"><marker>alas-dos</marker></example>
-			<example type="correct"><marker>alas-2</marker></example>
-		</rule>
-		<rule id="ALAS_INCORRECT_USAGE_NO_GITLING" name="Maling paggamit ng 'alas' (alas (una|1))">
-			<pattern case_sensitive="no">
-				<token>alas</token>
-				<token regexp="yes">una|1</token>
-			</pattern>
-  			<message>Nais mo bang gamitin ang <suggestion>ala-una</suggestion>?</message>
-			<short>Gamitin ang ala-una imbes na alas-una.</short>
-			<example correction="ala-una" type="incorrect"><marker>alas una</marker></example>
-			<example correction="ala-1" type="incorrect"><marker>alas 1</marker></example>
-			<example type="correct"><marker>ala-una</marker></example>
-		</rule>
-		<rule id="FUSED_ALA_UNA" name="Pinagdikit na 'alauna'">
-			<pattern case_sensitive="no">
-				<token regexp="yes">ala(una|1)</token>
-			</pattern>
-			<message>Nais mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1" regexp_match="^(ala)(.+)$" regexp_replace="$1-una"/></suggestion>.</message>			
-			<short>Gamitin ang ala-una imbes na alauna.</short>
-			<example correction="ala-una" type="incorrect"><marker>alauna</marker></example>
-			<example correction="ala-1" type="incorrect"><marker>ala1</marker></example>
-			<example type="correct"><marker>ala-una</marker></example>
-		</rule>
-		<rule id="FUSED_ALAS_DOS_TO_DOSE" name="Pinagdikit na 'alas(dos->dose)'">
-			<pattern case_sensitive="no">
-				<token regexp="yes">alas(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
-			</pattern>
-			<message>Nais mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1" regexp_match="^(alas)(.+)$" regexp_replace="$1-$2"/></suggestion>.</message>			
-			<short>Gamitin ang alas-(2-12 / dos-dose) imbes na pagdikitin ang ala at oras mula 2-12.</short>
-			<example correction="alas-dos" type="incorrect"><marker>alasdos</marker></example>
-			<example correction="alas-2" type="incorrect"><marker>alas2</marker></example>
-			<example type="correct"><marker>alas-dos</marker></example>
-			<example type="correct"><marker>alas-2</marker></example>
-		</rule>
-		<rule id="FUSED_INVALID_ALA" name="Pinagdikit na 'ala' na may maling oras">
-			<pattern case_sensitive="no">
-				<token regexp="yes">ala(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
-			</pattern>
-			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(ala)(.+)$" regexp_replace="alas-$2"/></suggestion>?</message>
-			<short>Gamitin ang alas (hindi ala) para sa mga oras mula 2–12.</short>
-			<example correction="alas-2" type="incorrect"><marker>ala2</marker></example>
-			<example correction="alas-4" type="incorrect"><marker>ala4</marker></example>
-			<example correction="alas-dos" type="incorrect"><marker>alados</marker></example>
-			<example type="correct"><marker>alas-2</marker></example>
-			<example type="correct"><marker>alas-dos</marker></example>
-		</rule>
-		<rule id="FUSED_INVALID_ALAS" name="Pinagdikit na 'alas' na may maling oras">
-			<pattern case_sensitive="no">
-				<token regexp="yes">alas(una|1)</token>
-			</pattern>	
-			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(alas)(.+)$" regexp_replace="ala-una"/></suggestion>?</message>
-			<short>Gamitin ang ala (not alas) para sa ala-una.</short>	
-			<example correction="ala-una" type="incorrect"><marker>alasuna</marker></example>
-			<example correction="ala-1" type="incorrect"><marker>alas1</marker></example>
-			<example type="correct"><marker>ala-una</marker></example>
-		</rule>
-    </category>
 	<category id="PAGPAPALIT_D_TUNGO_SA_R" name="Pagpapalit ng D tungo sa R">
 		<rule id="KATINIG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
@@ -234,7 +107,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>mag-aral</marker></example>
 			<example type="correct"><marker>nag-iisa</marker></example>
 		</rule>
-		<rule id="DE_GITLING" name="Paggamit ng gitling sa 'de'">
+		<rule id="KASUNOD_NG_DE" name="Paggamit ng gitling sa 'de'">
 			<pattern case_sensitive="no">
 				<token>de</token>
 				<token regexp="yes">^[a-zA-Z].*</token>
@@ -246,7 +119,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>de-lata</marker></example>
 			<example type="correct"><marker>de-kalidad</marker></example>
 		</rule>
-		<rule id="DI_GITLING" name="Paggamit ng gitling sa 'di'">
+		<rule id="KASUNOD_NG_DI" name="Paggamit ng gitling sa 'di'">
 			<pattern case_sensitive="no">
 				<token>di</token>
 				<token regexp="yes">^[a-zA-Z].*</token>
@@ -265,10 +138,82 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1"/>-<match no="1"/></suggestion>.</message>
 			<short>Gamitin ang gitling sa pagitan ng inuulit na salita.</short>
-			<example correction="gabi gabi" type="incorrect"><marker>gabi gabi</marker></example>
-			<example correction="araw araw" type="incorrect"><marker>araw araw</marker></example>
+			<example correction="gabi gabi" type="incorrect">gabi gabi</example>
+			<example correction="araw araw" type="incorrect">araw araw</example>
 			<example type="correct"><marker>gabi-gabi</marker></example>
 			<example type="correct"><marker>araw-araw</marker></example>
+		</rule>
+		<rule id="PASULAT_NA_ORAS_IKA" name="Paggamit ng gitling sa 'ika-' na sinusundan ng numero">
+            <pattern case_sensitive="no">
+                <token regexp="yes">ika(\d+)</token>
+            </pattern>
+            <message>Ginagamit ang gitling (-) upang ihiwalay ang numero sa petsa o oras na may 'ika-'. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(ika)(\d+)$" regexp_replace="ika-$2"/></suggestion>.</message>
+            <short>Dapat may gitling sa pagitan ng 'ika-' at numero.</short>
+            <example correction="ika8">ika8</example>
+            <example correction="ika100">ika100</example>
+            <example type="correct">ika-8</example>
+            <example type="correct">ikawalo</example>
+        </rule>
+		<rule id="PASULAT_NA_ORAS_IKA_SPACE" name="Paggamit ng gitling sa 'ika-' (may espasyo)">
+			<pattern case_sensitive="no">
+				<token>ika</token>
+				<token regexp="yes">\d+</token>
+			</pattern>
+			<message>Ginagamit ang gitling (-) upang ihiwalay ang numero sa petsa o oras na may 'ika-'. Isaalang-alang ang <suggestion>ika-<match no="2"/></suggestion>.</message>
+			<short>Dapat may gitling sa pagitan ng 'ika-' at numero.</short>
+			<example correction="ika 8">ika 8</example>
+			<example correction="ika 100">ika 100</example>
+			<example type="correct">ika-8</example>
+			<example type="correct">ikawalo</example>
+		</rule>
+		<rule id="PASULAT_NA_ORAS_ALAS" name="Paggamit ng gitling sa 'alas-' na sinusundan ng numero o salita">
+            <pattern case_sensitive="no">
+                <token regexp="yes">alas(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
+            </pattern>
+            <message>Ginagamit ang gitling (-) upang ihiwalay ang numero o binaybay na oras sa 'alas-'. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(alas)(.*)$" regexp_replace="alas-$2"/></suggestion>.</message>
+            <short>Dapat may gitling sa pagitan ng 'alas-' at oras.</short>
+            <example correction="alas12">alas12</example>
+            <example correction="alas3">alas3</example>
+            <example correction="alastres">alastres</example>
+            <example type="correct">alas-12</example>
+            <example type="correct">alas-tres</example>
+        </rule>
+		<rule id="PASULAT_NA_ORAS_ALAS_SPACE" name="Paggamit ng gitling sa 'alas-' (may espasyo)">
+			<pattern case_sensitive="no">
+				<token>alas</token>
+				<token regexp="yes">(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
+			</pattern>
+			<message>Ginagamit ang gitling (-) upang ihiwalay ang numero o binaybay na oras sa 'alas-'. Isaalang-alang ang <suggestion>alas-<match no="2"/></suggestion>.</message>
+			<short>Dapat may gitling sa pagitan ng 'alas-' at oras.</short>
+			<example correction="alas 12">alas 12</example>
+			<example correction="alas 3">alas 3</example>
+			<example correction="alas tres">alas tres</example>
+			<example type="correct">alas-12</example>
+			<example type="correct">alas-tres</example>
+			<example type="correct">ala-una</example> 
+		</rule>
+		<rule id="PASULAT_NA_ORAS_ALA" name="Pagbaybay ng 'una' sa 'ala-una'">
+			<pattern case_sensitive="no">
+                <token regexp="yes">(alas-1|alas1|ala-1|ala1|alas-una|alasuna|ala-uno|alauna)</token>
+            </pattern>
+            <message>Tandaan: Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
+            <suggestion>ala-una</suggestion>
+            <short>Laging 'ala-una' ang baybay.</short>
+            <example correction="alas-1">alas-1</example>
+            <example correction="alas1">alas1</example>
+            <example correction="alauna">alauna</example>
+            <example type="correct">ala-una</example>
+        </rule>
+		<rule id="PASULAT_NA_ORAS_ALA_SPACE" name="Pagbaybay ng 'una' sa 'ala-una (may espasyo)">
+			<pattern case_sensitive="no">
+				<token>ala</token>
+				<token>una</token>
+			</pattern>
+			<message>Tandaan: Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
+			<suggestion>ala-una</suggestion>
+			<short>Laging 'ala-una' ang baybay.</short>
+			<example correction="ala-una">ala una</example>
+			<example type="correct">ala-una</example>
 		</rule>
 	</category>
 	<category id="WASTONG_PAGGAMIT_NG_KUDLIT" name="Pagpapaikli ng mga Salita">
@@ -296,18 +241,14 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<antipattern>
 				<token regexp="yes">(?i)(kompanya|kompleto|kompetisyon|kompromiso|kompanyon)</token>
 			</antipattern>
-
 			<pattern case_sensitive="no">
 				<token regexp="yes">(con|kon|kom)[pf].*</token>
 			</pattern>
-			
 			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(con|kon|kom)[pf](.*)$" regexp_replace="kump$2"/></suggestion>?</message>
 			<short>Palitan ng 'kump-' (ang F ay nagiging P).</short>
-			
 			<example correction="conferencia">conferencia</example>
 			<example correction="komportable">komportable</example>
 			<example correction="confortable">confortable</example>
-			
 			<example type="correct" anti_example="yes">kompanya</example>
 			<example type="correct" anti_example="yes">kompleto</example>
 		</rule>
@@ -315,20 +256,15 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<antipattern>
 				<token regexp="yes">(?i)(kombinasyon|kombat)</token>
 			</antipattern>
-
 			<pattern case_sensitive="no">
 				<token regexp="yes">(con|kon|kom)[bv].*</token>
 			</pattern>
-			
 			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(con|kon|kom)[bv](.*)$" regexp_replace="kumb$2"/></suggestion>?</message>
 			<short>Palitan ng 'kumb-' (ang V ay nagiging B).</short>
-			
 			<example correction="kombensiyon">kombensiyon</example>
-			
 			<example type="correct" anti_example="yes">kombinasyon</example>
 			<example type="correct" anti_example="yes">kombat</example>
 		</rule>
-
         <rule id="KAPAG_NAGBAGO_ANG_PANTIG_ESPANYOL_EKSEPSIYON" name="Palitang O/U (mga eksepsiyon, kum -> kom)">
             <pattern case_sensitive="no">
                 <token regexp="yes">kum(panya|pleto|petisyon|binasyon)</token>
@@ -339,7 +275,6 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="kumpleto">kumpleto</example>
             <example type="correct">kompanya</example>
         </rule>
-
         <rule id="KAPAG_NAGBAGO_ANG_PANTIG_EXCEPTION" name="Maling pagpalit ng O sa U (ibang kaso)">
             <pattern case_sensitive="no">
                 <token regexp="yes">[km]un(?!p|b|f|v).*</token>
@@ -350,11 +285,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="munumento">munumento</example>
             <example type="correct">kontrata</example>
         </rule>
-
-		<rule id="	EPEKTO_NG_HULAPI_E_TO_I" name="Pagpalit ng E sa I (Epekto ng Hulapi)">
-            <antipattern>
-                <token regexp="yes">(?i)(basehan|kortehan)</token>
-            </antipattern>
+		<rule id="EPEKTO_NG_HULAPI_E_TO_I" name="Pagpalit ng E sa I (Epekto ng Hulapi)">
             <pattern case_sensitive="no">
                 <token regexp="yes">.*e(han|hin|in|an)$</token>
             </pattern>
@@ -364,13 +295,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="balaihin">Siya ay <marker>balaehin</marker> ko.</example>
             <example correction="onsihan">Ang <marker>onsehan</marker> ay nauwi sa gulo.</example>
             <example type="correct">kababaihan</example>
-            <example type="correct" anti_example="yes">basehan</example>
         </rule>
-
         <rule id="EPEKTO_NG_HULAPI_O_TO_U" name="Pagpalit ng O sa U (Epekto ng Hulapi)">
-            <antipattern>
-                <token regexp="yes">(?i)(bobohan|teleponohan)</token>
-            </antipattern>
             <pattern case_sensitive="no">
                 <token regexp="yes">.*o(han|hin|in|an)$</token>
             </pattern>
@@ -380,31 +306,6 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="kalbuhin">Balak niyang <marker>kalbohin</marker> ang aso.</example>
             <example correction="takbuhan">Agad niyang <marker>takbohan</marker> ang bata.</example>
             <example type="correct">biruin</example>
-            <example type="correct" anti_example="yes">bobohan</example>
         </rule>
-	</category>
-	<category id="SAMPLE_TWO" name="Two Suggestions">
-		<rule id="Two suggestions" name="Rule with two suggestions">
-			<pattern>
-				<token>TEKSTO</token>
-			</pattern>
-			<message>Did you mean <suggestion>testone</suggestion> or <suggestion>testthree</suggestion>?</message>
-			<short>Rule that offers two suggestions.</short>
-			<example correction="testone" type="incorrect"><marker>teksto</marker></example>
-			<example correction="testthree" type="incorrect"><marker>teksto</marker></example>
-			<example type="correct"><marker>testone</marker></example>
-			<example type="correct"><marker>testthree</marker></example>
-		</rule>
-		<rule id="Another two suggestions" name="Another rule with two suggestions">
-			<pattern>
-				<token>TEKSTO</token>
-			</pattern>
-			<message>Did you mean <suggestion>optionone</suggestion> or <suggestion>optiontwo</suggestion>?</message>
-			<short>Another rule that offers two suggestions.</short>
-			<example correction="optionone" type="incorrect"><marker>teksto</marker></example>
-			<example correction="optiontwo" type="incorrect"><marker>teksto</marker></example>
-			<example type="correct"><marker>optionone</marker></example>
-			<example type="correct"><marker>optiontwo</marker></example>
-		</rule>
 	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -172,17 +172,29 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="umiyak rin" type="incorrect"><marker>umiyak din</marker></example>
 			<example type="correct"><marker>kumain rin</marker></example>
 		</rule>
-		<rule id="EXCEPTION_RIN_RAW" name="Eksepsiyon sa paggamit ng 'rin/raw' pagkatapos ng -ra, -ri, -raw, o -ray">
+		<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
 				<token>rin</token>
 			</pattern>
-			<message>Ibig mong sabihin <suggestion><match no="1"/> din</suggestion>? Kapag nagtatapos sa -ra, -ri, -raw, o -ray, huwag gumamit ng "rin".</message>
-			<short>Gamitin ang “din” sa halip ng “rin”.</short>
-			<example correction="pari din" type="incorrect"><marker>pari rin</marker></example>
-			<example correction="sobra din" type="incorrect"><marker>sobra rin</marker></example>
-			<example type="correct">pari din</example>
-			<example type="correct">sobra din</example>
+			<message>Ibig mo bang sabihin <suggestion><match no="1"/> din</suggestion>? Kapag nagtatapos sa -ra, -ri, -raw, o -ray, huwag gumamit ng "rin".</message>
+			<short>Gamitin ang "din" imbes na "rin".</short>
+			<example correction="maaari rin" type="incorrect"><marker>maaari rin</marker></example>
+			<example correction="araw rin" type="incorrect"><marker>araw rin</marker></example>
+			<example type="correct">maaari din</example>
+			<example type="correct">araw din</example>
+		</rule>
+		<rule id="EXCEPTION_RAW" name="Eksepsiyon sa paggamit ng 'raw' pagkatapos ng -ra, -ri, -raw, o -ray">
+			<pattern case_sensitive="no">
+				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
+				<token>raw</token>
+			</pattern>
+			<message>Ibig mo bang sabihin <suggestion><match no="1"/> daw</suggestion>? Kapag nagtatapos sa -ra, -ri, -raw, o -ray, huwag gumamit ng "raw".</message>
+			<short>Gamitin ang "daw" imbes na "raw".</short>
+			<example correction="maaari raw" type="incorrect"><marker>maaari raw</marker></example>
+			<example correction="araw raw" type="incorrect"><marker>araw raw</marker></example>
+			<example type="correct">maaari din</example>
+			<example type="correct">araw din</example>
 		</rule>
 	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -243,7 +243,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>araw daw</marker></example>
 		</rule>
 	</category>
-	<category id="PALITANG_E_I_AT_O_U" name="Palitang E/I at O/U">
+	<!--<category id="PALITANG_E_I_AT_O_U" name="Palitang E/I at O/U">
 		<rule_id="PALITANG_E_I" name="Palitang E at I (unang letra)">
 			<pattern case_sensitive="no">
 				<token>(istasyon|iskandalo|istilo)</token>
@@ -255,6 +255,24 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 				<token></token>
 			</pattern>
 			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="" regexp_replace=""></suggestion>?</message>
+		</rule>
+	</category>-->
+	<category id="WASTONG_PAGGAMIT_NG_GITLING" name="Wastong Paggamit ng Gitling">
+		<rule id="PAGHIHIWALAY_NG_KATINIG_SA_PATINIG" name="Paghiwalay ng katinig sa patinig gamit ang gitling">
+			<pattern case_sensitive="no">
+				<token regexp="yes">(pag|mag|nag|pang)</token>
+				<token regexp="yes">^[aeiou].*</token>
+			</pattern>
+			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1"/>-<match no="2"/></suggestion>.</message>
+			<short>Gamitin ang gitling upang paghiwalayin ang unang katinig sa sumusunod na patinig.</short>
+			<example correction="pag-ibig" type="incorrect"><marker>pag ibig</marker></example>
+			<example correction="mag-aral" type="incorrect"><marker>mag aral</marker></example>
+			<example correction="nag-iisa" type="incorrect"><marker>nag iisa</marker></example>
+			<example correction="pang-ulo" type="incorrect"><marker>pang ulo</marker></example>
+			<example type="correct"><marker>pag-ibig</marker></example>
+			<example type="correct"><marker>mag-aral</marker></example>
+			<example type="correct"><marker>nag-iisa</marker></example>
+			<example type="correct"><marker>pang-ulo</marker></example>
 		</rule>
 	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -131,17 +131,20 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>di-kagandahan</marker></example>
 			<example type="correct"><marker>di-mahipo</marker></example>	
 		</rule>
-		<rule id="INUUULIT_NA_SALITA" name="Paggamit ng gitling sa inuulit na salita">
+		<rule id="INUULIT_NA_SALITA" name="Paggamit ng gitling sa inuulit na salita (pinagdikit)">
+			<antipattern>
+				<token regexp="yes">(paroparo|gamogamo)</token>
+			</antipattern>
 			<pattern case_sensitive="no">
-				<token regexp="yes">[a-zA-Z]+</token>
-				<token regexp="yes">\1</token>
+				<token regexp="yes">^(\w{3,})\1$</token>
 			</pattern>
-			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1"/>-<match no="1"/></suggestion>.</message>
-			<short>Gamitin ang gitling sa pagitan ng inuulit na salita.</short>
-			<example correction="gabi gabi" type="incorrect">gabi gabi</example>
-			<example correction="araw araw" type="incorrect">araw araw</example>
-			<example type="correct"><marker>gabi-gabi</marker></example>
-			<example type="correct"><marker>araw-araw</marker></example>
+			<message>Ginagamit ang gitling (-) sa mga salitang inuulit. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w{3,})\1$" regexp_replace="$1-$1"/></suggestion>.</message>
+			<short>Lagyan ng gitling ang inuulit na salita.</short>
+			<example correction="araw-araw">Ginagawa niya ito <marker>arawaraw</marker>.</example>
+			<example correction="gabi-gabi">Umuulan tuwing <marker>gabigabi</marker>.</example>
+			<example correction="balik-balik">Siya ay <marker>balikbalik</marker> sa tindahan.</example>
+			<example type="correct">araw-araw</example>
+			<example type="correct">paruparo</example> 
 		</rule>
 		<rule id="PASULAT_NA_ORAS_IKA" name="Paggamit ng gitling sa 'ika-' na sinusundan ng numero">
             <pattern case_sensitive="no">

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -218,45 +218,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct">maaari daw</example>
 			<example type="correct">araw daw</example>
 		</rule> 
-	<!--	<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
-			<pattern case_sensitive="no">
-				<token>(maaari|araw|biray|)</token>
-				<token>rin</token>
-			</pattern>
-			<message>Ibig mo bang sabihin <suggestion><match no="1"/> din</suggestion>? Kapag nagtatapos sa -ra, -ri, -raw, o -ray, huwag gumamit ng "rin".</message>
-			<short>Gamitin ang "din" imbes na "rin".</short>
-			<example correction="maaari din" type="incorrect"><marker>maaari rin</marker></example>
-			<example correction="araw din" type="incorrect"><marker>araw rin</marker></example>
-			<example type="correct"><marker>maaari din</marker></example>
-			<example type="correct"><marker>araw din</marker></example>
-		</rule>
-		<rule id="EXCEPTION_RAW" name="Eksepsiyon sa paggamit ng 'raw' pagkatapos ng -ra, -ri, -raw, o -ray">
-			<pattern case_sensitive="no">
-				<token>(maaari|araw|biray|)</token>
-				<token>raw</token>
-			</pattern>
-			<message>Ibig mo bang sabihin <suggestion><match no="1"/> daw</suggestion>? Kapag nagtatapos sa -ra, -ri, -raw, o -ray, huwag gumamit ng "raw".</message>
-			<short>Gamitin ang "daw" imbes na "raw".</short>
-			<example correction="maaari daw" type="incorrect"><marker>maaari raw</marker></example>
-			<example correction="araw daw" type="incorrect"><marker>araw raw</marker></example>
-			<example type="correct"><marker>maaari daw</marker></example>
-			<example type="correct"><marker>araw daw</marker></example>
-		</rule>-->
 	</category>
-	<!--<category id="PALITANG_E_I_AT_O_U" name="Palitang E/I at O/U">
-		<rule_id="PALITANG_E_I" name="Palitang E at I (unang letra)">
-			<pattern case_sensitive="no">
-				<token>(istasyon|iskandalo|istilo)</token>
-			</pattern>
-			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="\bi(.*)" regexp_replace="e$1"></suggestion>?</message>
-		</rule>
-		<rule_id="PALITANG_O_U" name="Palitang O at U (unang letra)">
-			<pattern case_sensitive="no">
-				<token></token>
-			</pattern>
-			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="" regexp_replace=""></suggestion>?</message>
-		</rule>
-	</category>-->
 	<category id="WASTONG_PAGGAMIT_NG_GITLING" name="Wastong Paggamit ng Gitling">
 		<rule id="PAGHIHIWALAY_NG_KATINIG_SA_PATINIG" name="Paghiwalay ng katinig sa patinig gamit ang gitling">
 			<pattern case_sensitive="no">
@@ -296,6 +258,18 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>di-kagandahan</marker></example>
 			<example type="correct"><marker>di-mahipo</marker></example>	
 		</rule>
+		<rule id="INUUULIT_NA_SALITA" name="Paggamit ng gitling sa inuulit na salita">
+			<pattern case_sensitive="no">
+				<token regexp="yes">[a-zA-Z]+</token>
+				<token regexp="yes">\1</token>
+			</pattern>
+			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1"/>-<match no="1"/></suggestion>.</message>
+			<short>Gamitin ang gitling sa pagitan ng inuulit na salita.</short>
+			<example correction="gabi gabi" type="incorrect"><marker>gabi gabi</marker></example>
+			<example correction="araw araw" type="incorrect"><marker>araw araw</marker></example>
+			<example type="correct"><marker>gabi-gabi</marker></example>
+			<example type="correct"><marker>araw-araw</marker></example>
+		</rule>
 	</category>
 	<category id="WASTONG_PAGIKLI_NG_SALITA" name="Pagpapaikli ng mga Salita">
 		<rule id="KUDLIT_YAN_YON" name="Paggamit ng kudlit sa yan/yon">
@@ -318,27 +292,24 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<short>Gamitin ang kudlit sa s'ya.</short>
 		</rule>
 	</category>
-	<category id="SALITANG_INUULIT" name="Salitang Inuulit">
-		<rule id="INUUULIT_NA_SALITA" name="Paggamit ng gitling sa inuulit na salita">
+	<category id="PALITANG E/I AT O/U" name="Palitang E/I at O/U">
+		<rule id="KAPAG_NAGBAGO_ANG_PANTIG_KUMP" name="Palitang O/U (con/kon/kom -> kump)">
+			<antipattern>
+				<token regexp="yes">(?i)(kompanya|kompleto|kompetisyon|kompromiso|kompanyon)</token>
+			</antipattern>
+		
 			<pattern case_sensitive="no">
-				<token regexp="yes">[a-zA-Z]+</token>
-				<token regexp="yes">\1</token>
+				<token regexp="yes">(con|kon|kom)[pf].*</token>
 			</pattern>
-			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1"/>-<match no="1"/></suggestion>.</message>
-			<short>Gamitin ang gitling sa pagitan ng inuulit na salita.</short>
-			<example correction="gabi gabi" type="incorrect"><marker>gabi gabi</marker></example>
-			<example correction="araw araw" type="incorrect"><marker>araw araw</marker></example>
-			<example type="correct"><marker>gabi-gabi</marker></example>
-			<example type="correct"><marker>araw-araw</marker></example>
-		</rule>
-	</category>
-	<category id="HULAPI" name="Wastong Pagbaybay ng Salita na may Hulapi">
-		<rule id="O_U_HAN_HIN" name="Pagbaybay ng hulaping -han/-hin">
-			<pattern case_sensitive="no">
-				<token regexp="yes">[a-zA-Z]+</token>
-				<token regexp="yes" spacebefore="no">(han|hin)</token>
-			</pattern>
-			<message>Ibig mo bang sabihin <suggestion><
+			
+			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(con|kon|kom)[pf](.*)$" regexp_replace="kump$2"/></suggestion>?</message>
+			<short>Palitan ng 'kump-' (ang F ay nagiging P).</short>
+			<example correction="conferencia">conferencia</example>
+			<example correction="komportable">komportable</example>
+			<example correction="kumpleto">kumpleto</example>
+			
+			<example type="correct">kompanya</example>
+			<example type="correct">kompleto</example>
 		</rule>
 	</category>
 	<category id="SAMPLE_TWO" name="Two Suggestions">

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -172,6 +172,28 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="umiyak rin" type="incorrect"><marker>umiyak din</marker></example>
 			<example type="correct"><marker>kumain rin</marker></example>
 		</rule>
+		<rule id="KATINIG_RAW" name="Maling paggamit ng 'raw' pagkatapos ng katinig">
+			<pattern case_sensitive="no">
+				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
+				<token>raw</token>
+			</pattern>
+			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> daw</suggestion>?</message>
+			<short>Gamitin ang daw kung ang sinusundang salita ay nagtatapos sa katinig.</short>
+			<example correction="kumain daw" type="incorrect"><marker>kumain raw</marker></example>
+			<example correction="lumakad daw" type="incorrect"><marker>lumakad raw</marker></example>
+			<example type="correct"><marker>kumain daw</marker></example>
+		</rule>
+		<rule id="PATINIG_DAW" name="Maling paggamit ng 'daw' pagkatapos ng patinig o malapatinig">
+			<pattern case_sensitive="no">
+				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[aeiouwy]$</token>
+				<token>daw</token>
+			</pattern>
+			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> raw</suggestion>?</message>
+			<short>Gamitin ang raw kung ang sinusundang salita ay nagtatapos sa patinig o malapatinig.</short>
+			<example correction="kumain raw" type="incorrect"><marker>kumain daw</marker></example>
+			<example correction="umiyak raw" type="incorrect"><marker>umiyak daw</marker></example>
+			<example type="correct"><marker>kumain raw</marker></example>
+		</rule>
 		<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*(ra|ri|raw|ray)$</token>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -298,15 +298,15 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 		</rule>
 	</category>
 	<category id="WASTONG_PAGIKLI_NG_SALITA" name="Pagpapaikli ng mga Salita">
-		<rule id="KUDLIT_YAN_YUN_YON" name="Paggamit ng kudlit sa yan/yun/yon">
+		<rule id="KUDLIT_YAN_YON" name="Paggamit ng kudlit sa yan/yon">
 			<pattern case_sensitive="no">
 				<token regexp="yes">[a-zA-Z]+</token>
-				<token regexp="yes">yan|yun|yon</token>
+				<token regexp="yes">yan|yon</token>
 			</pattern>
 			<message>Ibig mo bang gumamit ng kudlit? Gamitin ang <suggestion>'<match no="1"/></suggestion>.</message>
-			<short>Gamitin ang kudlit sa pagitan ng salita at 'yan.</short>
-			<example correction="bahay 'yan" type="incorrect"><marker>bahay yan</marker></example>
-			<example correction="kapatid 'yan" type="incorrect"><marker>kapatid yan</marker></example>
+			<short>Gamitin ang kudlit sa pagitan ng salita at 'yan/'yon.</short>
+			<example correction="bahay yan" type="incorrect"><marker>bahay yan</marker></example>
+			<example correction="kapatid yan" type="incorrect"><marker>kapatid yan</marker></example>
 			<example type="correct"><marker>bahay 'yan</marker></example>
 			<example type="correct"><marker>kapatid 'yan</marker></example>
 		</rule>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -105,7 +105,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="ala-1" type="incorrect"><marker>alas 1</marker></example>
 			<example type="correct"><marker>ala-una</marker></example>
 		</rule>
-		<rule id="FUSED_ALA_UNA" name="Fused 'alauna' or 'ala1'">
+		<rule id="FUSED_ALA_UNA" name="Pinagdikit na 'alauna'">
 			<pattern case_sensitive="no">
 				<token regexp="yes">ala(una|1)</token>
 			</pattern>
@@ -115,7 +115,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="ala-1" type="incorrect"><marker>ala1</marker></example>
 			<example type="correct"><marker>ala-una</marker></example>
 		</rule>
-		<rule id="FUSED_ALAS_DOS_TO_DOSE" name="Fused 'alasdos' to 'alasdose'">
+		<rule id="FUSED_ALAS_DOS_TO_DOSE" name="Pinagdikit na 'alas(dos->dose)'">
 			<pattern case_sensitive="no">
 				<token regexp="yes">alas(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
 			</pattern>
@@ -126,7 +126,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>alas-dos</marker></example>
 			<example type="correct"><marker>alas-2</marker></example>
 		</rule>
-		<rule id="FUSED_INVALID_ALA" name="Fused 'ala' with invalid time">
+		<rule id="FUSED_INVALID_ALA" name="Pinagdikit na 'ala' na may maling oras">
 			<pattern case_sensitive="no">
 				<token regexp="yes">ala(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
 			</pattern>
@@ -138,12 +138,12 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>alas-2</marker></example>
 			<example type="correct"><marker>alas-dos</marker></example>
 		</rule>
-		<rule id="FUSED_INVALID_ALAS" name="Fused 'alas' with invalid time">
+		<rule id="FUSED_INVALID_ALAS" name="Pinagdikit na 'alas' na may maling oras">
 			<pattern case_sensitive="no">
 				<token regexp="yes">alas(una|1)</token>
 			</pattern>	
-			<message>Did you mean <suggestion><match no="1" regexp_match="^(alas)(.+)$" regexp_replace="ala-una"/></suggestion>?</message>
-			<short>Use ala (not alas) with una.</short>	
+			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(alas)(.+)$" regexp_replace="ala-una"/></suggestion>?</message>
+			<short>Gamitin ang ala (not alas) para sa ala-una.</short>	
 			<example correction="ala-una" type="incorrect"><marker>alasuna</marker></example>
 			<example correction="ala-1" type="incorrect"><marker>alas1</marker></example>
 			<example type="correct"><marker>ala-una</marker></example>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -265,27 +265,39 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1"/>-<match no="2"/></suggestion>.</message>
 			<short>Gamitin ang gitling upang paghiwalayin ang unang katinig sa sumusunod na patinig.</short>
-			<example correction="pag-ibig" type="incorrect"><marker>pag ibig</marker></example>
-			<example correction="mag-aral" type="incorrect"><marker>mag aral</marker></example>
-			<example correction="nag-iisa" type="incorrect"><marker>nag iisa</marker></example>
+			<example correction="pag ibig" type="incorrect"><marker>pag ibig</marker></example>
+			<example correction="mag aral" type="incorrect"><marker>mag aral</marker></example>
+			<example correction="nag iisa" type="incorrect"><marker>nag iisa</marker></example>
 			<example type="correct"><marker>pag-ibig</marker></example>
 			<example type="correct"><marker>mag-aral</marker></example>
 			<example type="correct"><marker>nag-iisa</marker></example>
 		</rule>
-		<rule id="DE_DI_GITLING" name="Paggamit ng gitling sa 'de' at 'di'">
+		<rule id="DE_GITLING" name="Paggamit ng gitling sa 'de'">
 			<pattern case_sensitive="no">
-				<token>de|di</token>
+				<token>de</token>
 				<token regexp="yes">[a-zA-Z]</token>
 			</pattern>
 			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion>de-<match no="2"/></suggestion>.</message>
 			<short>Gamitin ang gitling pagkatapos ng 'de' kapag sinusundan ito ng salita.</short>
-			<example correction="de-lata" type="incorrect"><marker>de lata</marker></example>
-			<example correction="de-kalidad" type="incorrect"><marker>de kalidad</marker></example>
+			<example correction="de lata" type="incorrect"><marker>de lata</marker></example>
+			<example correction="de kalidad" type="incorrect"><marker>de kalidad</marker></example>
 			<example type="correct"><marker>de-lata</marker></example>
 			<example type="correct"><marker>de-kalidad</marker></example>	]
 		</rule>
+		<rule id="DI_GITLING" name="Paggamit ng gitling sa 'di'">
+			<pattern case_sensitive="no">
+				<token>di</token>
+				<token regexp="yes">[a-zA-Z]</token>
+			</pattern>
+			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion>di-<match no="2"/></suggestion>.</message>
+			<short>Gamitin ang gitling pagkatapos ng 'di' kapag sinusundan ito ng salita.</short>
+			<example correction="di kagandahan" type="incorrect"><marker>di kagandahan</marker></example>
+			<example correction="di mahipo" type="incorrect"><marker>di mahipo</marker></example>
+			<example type="correct"><marker>di-kagandahan</marker></example>
+			<example type="correct"><marker>di-mahipo</marker></example>	]
+		</rule>
 	</category>
-	<category id="CONTRACTIONS" name="Pagpapaikli ng mga Salita">
+	<category id="WASTONG_PAGIKLI_NG_SALITA" name="Pagpapaikli ng mga Salita">
 		<rule id="KUDLIT_YAN_YUN_YON" name="Paggamit ng kudlit sa yan/yun/yon">
 			<pattern case_sensitive="no">
 				<token regexp="yes">[a-zA-Z]+</token>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -152,7 +152,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 	<category id="CONSONANT_ALTERNATION" name="Pagpapalit ng D tungo sa R">
 		<rule id="KATINIG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
-				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[b-df-hj-np-tv-z]$</token>
+				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[b-df-hj-np-tv-xz]$</token>
 				<token>rin</token>
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> din</suggestion>?</message>
@@ -161,9 +161,9 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="lumakad din" type="incorrect"><marker>lumakad rin</marker></example>
 			<example type="correct"><marker>kumain din</marker></example>
 		</rule>
-		<rule id="PATINIG_DIN" name="Maling paggamit ng 'din' pagkatapos ng patinig">
+		<rule id="PATINIG_DIN" name="Maling paggamit ng 'din' pagkatapos ng patinig o malapatinig">
 			<pattern case_sensitive="no">
-				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[aeiou]$</token>
+				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[aeiouwy]$</token>
 				<token>din</token>
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> rin</suggestion>?</message>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -23,7 +23,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 -->
 <rules lang="tl" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<category id="PAGPAPALIT_D_TUNGO_SA_R" name="Pagpapalit ng D tungo sa R">
-		<rule id="KATINIG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
+		<rule id="KASONG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
 			<token regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
 				<token>rin</token>
@@ -34,7 +34,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="lumakad din" type="incorrect"><marker>lumakad rin</marker></example>
 			<example type="correct"><marker>kumain din</marker></example>
 		</rule>
-		<rule id="PATINIG_DIN" name="Maling paggamit ng 'din' pagkatapos ng patinig o malapatinig">
+		<rule id="KASONG_DIN" name="Maling paggamit ng 'din' pagkatapos ng patinig o malapatinig">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*[aeiouwy]$</token>
 				<token>din</token>
@@ -45,7 +45,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="umiyak rin" type="incorrect"><marker>umiyak din</marker></example>
 			<example type="correct"><marker>kumain rin</marker></example>
 		</rule>
-		<rule id="KATINIG_RAW" name="Maling paggamit ng 'raw' pagkatapos ng katinig">
+		<rule id="KASONG_RAW" name="Maling paggamit ng 'raw' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
 				<token>raw</token>
@@ -56,7 +56,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="lumakad daw" type="incorrect"><marker>lumakad raw</marker></example>
 			<example type="correct"><marker>kumain daw</marker></example>
 		</rule>
-		<rule id="PATINIG_DAW" name="Maling paggamit ng 'daw' pagkatapos ng patinig o malapatinig">
+		<rule id="KASONG_DAW" name="Maling paggamit ng 'daw' pagkatapos ng patinig o malapatinig">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*[aeiouwy]$</token>
 				<token>daw</token>
@@ -67,7 +67,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="umiyak raw" type="incorrect"><marker>umiyak daw</marker></example>
 			<example type="correct"><marker>kumain raw</marker></example>
 		</rule>
-		<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
+		<rule id="EXCEPTION_SA_KASONG_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
 				<token>rin</token>
@@ -79,7 +79,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct">maaari din</example>
 			<example type="correct">araw din</example>
 		</rule>
-		<rule id="EXCEPTION_RAW" name="Eksepsiyon sa paggamit ng 'raw' pagkatapos ng -ra, -ri, -raw, o -ray">
+		<rule id="EXCEPTION_SA_KASONG_RAW" name="Eksepsiyon sa paggamit ng 'raw' pagkatapos ng -ra, -ri, -raw, o -ray">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
 				<token>raw</token>
@@ -140,21 +140,22 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ginagamit ang gitling (-) sa mga salitang inuulit. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w{3,})\1$" regexp_replace="$1-$1"/></suggestion>.</message>
 			<short>Lagyan ng gitling ang inuulit na salita.</short>
-			<example correction="araw-araw">Ginagawa niya ito <marker>arawaraw</marker>.</example>
-			<example correction="gabi-gabi">Umuulan tuwing <marker>gabigabi</marker>.</example>
-			<example correction="balik-balik">Siya ay <marker>balikbalik</marker> sa tindahan.</example>
+			<example correction="araw araw" type="incorrect"><marker>arawaraw</marker></example>
+			<example correction="gabi gabi" type="incorrect"><marker>gabigabi</marker></example>
+			<example correction="balik balik" type="incorrect"><marker>balikbalik</marker></example>
 			<example type="correct">araw-araw</example>
 			<example type="correct">paruparo</example> 
 		</rule>
 		<rule id="INUULIT_NA_SALITA_MAHIGIT_DALAWANG_PANTIG" name="Paggamit ng gitling sa inuulit na salita (pinagdikit)">
 			<pattern case_sensitive="no">
-				<token regexp="yes">(palipalito|balubaluktot|balibaligtad|bulabulagsak)</token>
+				<token regexp="yes">\b(palipalito|balubaluktot|balibaligtad|bulabulagsak)\b</token>
 			</pattern>
-			<message>Ginagamit ang gitling (-) sa mga salitang inuulit. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(pali)(palito)$" regexp_replace="$1-$2"/></suggestion><suggestion><match no="1" regexp_match="^(balu)(baluktot)$" regexp_replace="$1-$2"/></suggestion><suggestion><match no="1" regexp_match="^(bali)(baligtad)$" regexp_replace="$1-$2"/></suggestion><suggestion><match no="1" regexp_match="^(bula)(bulagsak)$" regexp_replace="$1-$2"/></suggestion>.</message>
+			<message>Ginagamit ang gitling (-) sa mga salitang inuulit. Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^([a-z]{4})([a-z]+)$" regexp_replace="$1-$2"/></suggestion>?</message>
 			<short>Lagyan ng gitling ang inuulit na salita.</short>
-			<example correction="pali-palito">palipalito</example>
-			<example correction="balu-baluktot">balubaluktot</example>
-			<example correction="bali-baligtad">balibaligtad</example>
+			<example correction="palipalito" type="incorrect"><marker>palipalito</marker></example>
+			<example correction="balubaluktot" type="incorrect"><marker>balubaluktot</marker></example>
+			<example correction="balibaligtad" type="incorrect"><marker>balibaligtad</marker></example>
+			<example correction="bulabulagsak" type="incorrect"><marker>bulabulagsak</marker></example>
 			<example type="correct">pali-palito</example>
 		</rule>
 		<rule id="INUULIT_NA_SALITA_MAHIGIT_DALAWANG_PANTIG_SPACE" name="Paggamit ng gitling sa inuulit na salita (may espasyo)">
@@ -164,8 +165,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ginagamit ang gitling (-) sa mga salitang inuulit. Isaalang-alang ang <suggestion><match no="1"/>-<match no="2"/></suggestion>.</message>
 			<short>Lagyan ng gitling ang inuulit na salita.</short>
-			<example correction="pali-palito">pali palito</example>
-			<example correction="balu-baluktot">balu baluktot</example>
+			<example correction="pali palito" type="incorrect">pali palito</example>
+			<example correction="balu baluktot" type="incorrect">balu baluktot</example>
 			<example type="correct">pali-palito</example>
 		</rule>
 		<rule id="PASULAT_NA_ORAS_IKA" name="Paggamit ng gitling sa 'ika-' na sinusundan ng numero">
@@ -174,8 +175,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             </pattern>
             <message>Ginagamit ang gitling (-) upang ihiwalay ang numero sa petsa o oras na may 'ika-'. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(ika)(\d+)$" regexp_replace="ika-$2"/></suggestion>.</message>
             <short>Dapat may gitling sa pagitan ng 'ika-' at numero.</short>
-            <example correction="ika8">ika8</example>
-            <example correction="ika100">ika100</example>
+            <example correction="ika8" type="incorrect">ika8</example>
+            <example correction="ika100" type="incorrect">ika100</example>
             <example type="correct">ika-8</example>
             <example type="correct">ikawalo</example>
         </rule>
@@ -186,8 +187,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ginagamit ang gitling (-) upang ihiwalay ang numero sa petsa o oras na may 'ika-'. Isaalang-alang ang <suggestion>ika-<match no="2"/></suggestion>.</message>
 			<short>Dapat may gitling sa pagitan ng 'ika-' at numero.</short>
-			<example correction="ika 8">ika 8</example>
-			<example correction="ika 100">ika 100</example>
+			<example correction="ika 8" type="incorrect">ika 8</example>
+			<example correction="ika 100" type="incorrect">ika 100</example>
 			<example type="correct">ika-8</example>
 			<example type="correct">ikawalo</example>
 		</rule>
@@ -197,9 +198,9 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             </pattern>
             <message>Ginagamit ang gitling (-) upang ihiwalay ang numero o binaybay na oras sa 'alas-'. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(alas)(.*)$" regexp_replace="alas-$2"/></suggestion>.</message>
             <short>Dapat may gitling sa pagitan ng 'alas-' at oras.</short>
-            <example correction="alas12">alas12</example>
-            <example correction="alas3">alas3</example>
-            <example correction="alastres">alastres</example>
+            <example correction="alas12" type="incorrect">alas12</example>
+            <example correction="alas3" type="incorrect">alas3</example>
+            <example correction="alastres" type="incorrect">alastres</example>
             <example type="correct">alas-12</example>
             <example type="correct">alas-tres</example>
         </rule>
@@ -210,23 +211,23 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ginagamit ang gitling (-) upang ihiwalay ang numero o binaybay na oras sa 'alas-'. Isaalang-alang ang <suggestion>alas-<match no="2"/></suggestion>.</message>
 			<short>Dapat may gitling sa pagitan ng 'alas-' at oras.</short>
-			<example correction="alas 12">alas 12</example>
-			<example correction="alas 3">alas 3</example>
-			<example correction="alas tres">alas tres</example>
+			<example correction="alas 12" type="incorrect">alas 12</example>
+			<example correction="alas 3" type="incorrect">alas 3</example>
+			<example correction="alas tres" type="incorrect">alas tres</example>
 			<example type="correct">alas-12</example>
 			<example type="correct">alas-tres</example>
 			<example type="correct">ala-una</example> 
 		</rule>
 		<rule id="PASULAT_NA_ORAS_ALA" name="Pagbaybay ng 'una' sa 'ala-una'">
 			<pattern case_sensitive="no">
-                <token regexp="yes">(alas-1|alas1|ala-1|ala1|alas-una|alasuna|ala-uno|alauna)</token>
+                <token regexp="yes">(alas-1|alas1|ala-1|ala1|alas-una|alasuna|ala-uno|alauna|alauno)</token>
             </pattern>
             <message>Tandaan: Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
             <suggestion>ala-una</suggestion>
             <short>Laging 'ala-una' ang baybay.</short>
-            <example correction="alas-1">alas-1</example>
-            <example correction="alas1">alas1</example>
-            <example correction="alauna">alauna</example>
+            <example correction="alas-1" type="incorrect">alas-1</example>
+            <example correction="alas1" type="incorrect">alas1</example>
+            <example correction="alauna" type="incorrect">alauna</example>
             <example type="correct">ala-una</example>
         </rule>
 		<rule id="PASULAT_NA_ORAS_ALA_SPACE" name="Pagbaybay ng 'una' sa 'ala-una (may espasyo)">
@@ -237,7 +238,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<message>Tandaan: Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
 			<suggestion>ala-una</suggestion>
 			<short>Laging 'ala-una' ang baybay.</short>
-			<example correction="ala-una">ala una</example>
+			<example correction="ala una" type="incorrect">ala una</example>
 			<example type="correct">ala-una</example>
 		</rule>
 	</category>
@@ -255,10 +256,12 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 		</rule>
 		<rule id="MADALAS_NA_MGA_PINAPAIKLI" name="Mga salitang pinaikli">
 			<pattern case_sensitive="no">
-				<token>sya</token>
+				<token regexp="yes">sya|nya</token>
 			</pattern>
-			<message>Ibig mo bang sabihin, <suggestion>s'ya</suggestion>?</message>
+			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(s|n)(ya)$" regexp_replace="$1'ya"/></suggestion>?</message>
 			<short>Gamitin ang kudlit sa s'ya.</short>
+			<example correction="sya" type="incorrect">sya</example>
+			<example type="correct">s'ya</example>
 		</rule>
 	</category>
 	<category id="PALITANG E/I AT O/U" name="Palitang E/I at O/U">
@@ -271,9 +274,9 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(con|kon|kom)[pf](.*)$" regexp_replace="kump$2"/></suggestion>?</message>
 			<short>Palitan ng 'kump-' (ang F ay nagiging P).</short>
-			<example correction="conferencia">conferencia</example>
-			<example correction="komportable">komportable</example>
-			<example correction="confortable">confortable</example>
+			<example correction="conferencia" type="incorrect">conferencia</example>
+			<example correction="komportable" type="incorrect">komportable</example>
+			<example correction="confortable" type="incorrect">confortable</example>
 			<example type="correct" anti_example="yes">kompanya</example>
 			<example type="correct" anti_example="yes">kompleto</example>
 		</rule>
@@ -286,9 +289,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(con|kon|kom)[bv](.*)$" regexp_replace="kumb$2"/></suggestion>?</message>
 			<short>Palitan ng 'kumb-' (ang V ay nagiging B).</short>
-			<example correction="kombensiyon">kombensiyon</example>
-			<example type="correct" anti_example="yes">kombinasyon</example>
-			<example type="correct" anti_example="yes">kombat</example>
+			<example correction="kombensiyon" type="incorrect">kombensiyon</example>
+			<example type="correct">kumbensiyon</example>
 		</rule>
         <rule id="KAPAG_NAGBAGO_ANG_PANTIG_ESPANYOL_EKSEPSIYON" name="Palitang O/U (mga eksepsiyon, kum -> kom)">
             <pattern case_sensitive="no">
@@ -296,18 +298,18 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             </pattern>
             <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(kum)(panya|pleto|petisyon|binasyon)$" regexp_replace="kom$2"/></suggestion>?</message>
             <short>Dapat 'kom-' (hindi 'kum-') ang baybay ng salitang ito. Isa itong eksepsiyon.</short>
-            <example correction="kumpanya">kumpanya</example>
-            <example correction="kumpleto">kumpleto</example>
+            <example correction="kumpanya" type="incorrect">kumpanya</example>
+            <example correction="kumpleto" type="incorrect">kumpleto</example>
             <example type="correct">kompanya</example>
         </rule>
-        <rule id="KAPAG_NAGBAGO_ANG_PANTIG_EXCEPTION" name="Maling pagpalit ng O sa U (ibang kaso)">
+        <rule id="KAPAG_NAGBAGO_ANG_PANTIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso)">
             <pattern case_sensitive="no">
                 <token regexp="yes">[km]un(?!p|b|f|v).*</token>
             </pattern>
             <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^([km])(un)(.*)$" regexp_replace="$1on$3"/></suggestion>?</message>
             <short>Dapat manatili ang 'o' sa salitang ito.</short>
-            <example correction="kuntrata">kuntrata</example>
-            <example correction="munumento">munumento</example>
+            <example correction="kuntrata" type="incorrect">kuntrata</example>
+            <example correction="munumento" type="incorrect">munumento</example>
             <example type="correct">kontrata</example>
         </rule>
 		<rule id="EPEKTO_NG_HULAPI_E_TO_I" name="Pagpalit ng E sa I (Epekto ng Hulapi)">
@@ -316,9 +318,9 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             </pattern>
             <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(.*)e(han|hin|in|an)$" regexp_replace="$1i$2"/></suggestion>?</message>
             <short>Palitan ang 'e' ng 'i' kapag may hulapi.</short>
-            <example correction="kababaihan">Ang <marker>kababaehan</marker> ay para sa lahat.</example>
-            <example correction="balaihin">Siya ay <marker>balaehin</marker> ko.</example>
-            <example correction="onsihan">Ang <marker>onsehan</marker> ay nauwi sa gulo.</example>
+            <example correction="kababaihan" type="incorrect">Ang <marker>kababaehan</marker> ay para sa lahat.</example>
+            <example correction="balaihin" type="incorrect">Siya ay <marker>balaehin</marker> ko.</example>
+            <example correction="onsihan" type="incorrect">Ang <marker>onsehan</marker> ay nauwi sa gulo.</example>
             <example type="correct">kababaihan</example>
         </rule>
         <rule id="EPEKTO_NG_HULAPI_O_TO_U" name="Pagpalit ng O sa U (Epekto ng Hulapi)">
@@ -327,9 +329,9 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             </pattern>
             <message>Ibig mo bang sabihin<suggestion><match no="1" regexp_match="^(.*)o(han|hin|in|an)$" regexp_replace="$1u$2"/></suggestion>?</message>
             <short>Palitan ang 'o' ng 'u' kapag may hulapi.</short>
-            <example correction="biruin">Huwag mo siyang <marker>biroin</marker>.</example>
-            <example correction="kalbuhin">Balak niyang <marker>kalbohin</marker> ang aso.</example>
-            <example correction="takbuhan">Agad niyang <marker>takbohan</marker> ang bata.</example>
+            <example correction="biroin" type="incorrect">biroin</example>
+            <example correction="kalbuhin" type="incorrect">kalbohin</example>
+            <example correction="takbuhan" type="incorrect">takbohan</example>
             <example type="correct">biruin</example>
         </rule>
 	</category>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -152,7 +152,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 	<category id="CONSONANT_ALTERNATION" name="Pagpapalit ng D tungo sa R">
 		<rule id="KATINIG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
-				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[b-df-hj-np-tv-xz]$</token>
+			<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
 				<token>rin</token>
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> din</suggestion>?</message>
@@ -167,10 +167,22 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 				<token>din</token>
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> rin</suggestion>?</message>
-			<short>Gamitin ang rin kung ang sinusundang salita ay nagtatapos sa patinig.</short>
+			<short>Gamitin ang rin kung ang sinusundang salita ay nagtatapos sa patinig o malapatinig.</short>
 			<example correction="kumain rin" type="incorrect"><marker>kumain din</marker></example>
 			<example correction="umiyak rin" type="incorrect"><marker>umiyak din</marker></example>
 			<example type="correct"><marker>kumain rin</marker></example>
+		</rule>
+		<rule id="EXCEPTION_RIN_RAW" name="Eksepsiyon sa paggamit ng 'rin/raw' pagkatapos ng -ra, -ri, -raw, o -ray">
+			<pattern case_sensitive="no">
+				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
+				<token>rin</token>
+			</pattern>
+			<message>Ibig mong sabihin <suggestion><match no="1"/> din</suggestion>? Kapag nagtatapos sa -ra, -ri, -raw, o -ray, huwag gumamit ng "rin".</message>
+			<short>Gamitin ang “din” sa halip ng “rin”.</short>
+			<example correction="pari din" type="incorrect"><marker>pari rin</marker></example>
+			<example correction="sobra din" type="incorrect"><marker>sobra rin</marker></example>
+			<example type="correct">pari din</example>
+			<example type="correct">sobra din</example>
 		</rule>
 	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -30,11 +30,14 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			</pattern>
 			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> din</suggestion>?</message>
 			<short>Gamitin ang din kung ang sinusundang salita ay nagtatapos sa katinig.</short>
-			<example correction="kumain din" type="incorrect"><marker>kumain rin</marker></example>
+			<example correction="kumain din" type="incorrect"><marker>Kumain rin</marker> siya.</example>
 			<example correction="lumakad din" type="incorrect"><marker>lumakad rin</marker></example>
 			<example type="correct"><marker>kumain din</marker></example>
 		</rule>
 		<rule id="KASONG_DIN" name="Maling paggamit ng 'din' pagkatapos ng patinig o malapatinig">
+			<antipattern>
+				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
+			</antipattern>
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*[aeiouwy]$</token>
 				<token>din</token>
@@ -57,6 +60,9 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>kumain daw</marker></example>
 		</rule>
 		<rule id="KASONG_DAW" name="Maling paggamit ng 'daw' pagkatapos ng patinig o malapatinig">
+			<antipattern>
+				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
+			</antipattern>
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*[aeiouwy]$</token>
 				<token>daw</token>
@@ -238,7 +244,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<message>Tandaan: Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
 			<suggestion>ala-una</suggestion>
 			<short>Laging 'ala-una' ang baybay.</short>
-			<example correction="ala una" type="incorrect">ala una</example>
+			<example correction="ala-una" type="incorrect">ala una</example>
 			<example type="correct">ala-una</example>
 		</rule>
 	</category>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -22,74 +22,105 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 See tagset.txt for the different POS, Lexical Categories, and corresponding attributes
 -->
 <rules lang="tl" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <category id="PROPER_ALA_ALAS_USAGE" name="Proper ala/alas Usage">
-        <rule id="ALA_MISSING_GITLING" name="Gitling for 'ala-una'">
+    <category id="PROPER_ALA_ALAS_USAGE" name="Wastong Paggamit ng 'Ala' at 'Alas'">
+        <rule id="ALA_MISSING_GITLING" name="Gitling sa 'ala-una'">
 			<pattern case_sensitive="no">
 				<token>ala</token>
-				<token regexp="yes">una|1</token>
+				<token regexp="yes">una</token>
 			</pattern>
-			<message>Did you mean to add a gitling? Use <suggestion>ala-\2</suggestion>.</message>
-			<short>Use a gitling between "ala" and "una". "Ala" is used only for "una".</short>
+			<message>Nais mo bang gumamit ng gitling? Gamitin ang <suggestion>ala-una</suggestion>.</message>
+			<short>Gumamit ng gitling sa pagitan ng "ala" at "una". Ang "ala" ay para lamang sa "ala-una".</short>
 			<example correction="ala-una" type="incorrect"><marker>ala una</marker></example>
 			<example correction="ala-1" type="incorrect"><marker>ala 1</marker></example>
-			<example type="correct"><marker>ala-una"</marker></example>
-			<example type="correct"><marker>ala-1"</marker></example>
+			<example type="correct"><marker>ala-una</marker></example>
 		</rule>
-        <rule id="ALAS_MISSING_GITLING" name="Gitling for 'alas-(dos->dose)'">
+        <rule id="ALAS_MISSING_GITLING" name="Gitling sa 'alas-(dos->dose)'">
             <pattern case_sensitive="no">
                 <token>alas</token>
                 <token regexp="yes">(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
             </pattern>
-            <message>Did you mean to add a gitling? Use <suggestion>alas-\2</suggestion>.</message>
-            <short>Use a gitling between "alas" and time values between 2-12.</short>
+            <message>Nais mo bang gumamit ng gitling? Gamitin ang <suggestion>alas-\2</suggestion>.</message>
+            <short>Maglagay ng gitling sa pagitan ng "alas" at oras mula 2-12.</short>
             <example correction="alas-dos" type="incorrect"><marker>alas dos</marker></example>
 			<example correction="alas-2" type="incorrect"><marker>alas 2</marker></example>
 			<example type="correct"><marker>alas-dos</marker></example>
 			<example type="correct"><marker>alas-2</marker></example>
         </rule>
-		<rule id="ALA_INCORRECT_USAGE" name="Incorrect Usage for 'ala'">
+		<rule id="ALA_INCORRECT_USAGE_NUMERIC" name="Maling paggamit ng 'ala' (ala-1)">
+			<pattern case_sensitive="no">
+				<token>ala</token>
+				<token>-</token>
+				<token regexp="yes">1</token>
+			</pattern>
+  			<message>Nais mo bang gamitin ang <suggestion>ala-una</suggestion>?</message>
+			<short>Gamitin ang ala-una sa halip na ala-1.</short>
+			<example correction="ala-una" type="incorrect"><marker>ala-1</marker></example>
+			<example type="correct"><marker>ala-una</marker></example>
+		</rule>
+		<rule id="ALA_INCORRECT_USAGE" name="Maling paggamit ng 'ala' (ala-(dos->dose))">
 			<pattern case_sensitive="no">
 				<token>ala</token>
 				<token>-</token>
                 <token regexp="yes">(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
 			</pattern>
-  			<message>Did you mean to use <suggestion>alas-\3</suggestion>?</message>
-			<short>Use alas-(2-12 / dos-dose) instead of ala-(2-12 / dos-dose).</short>
+  			<message>Nais mo bang gamitin ang <suggestion>alas-\3</suggestion>?</message>
+			<short>Gamitin ang alas-(2-12 / dos-dose) imbes na ala-(2-12 / dos-dose).</short>
 			<example correction="alas-dos" type="incorrect"><marker>ala-dos</marker></example>
 			<example correction="alas-2" type="incorrect"><marker>ala-2</marker></example>
 			<example type="correct"><marker>alas-dos</marker></example>
 			<example type="correct"><marker>alas-2</marker></example>
 		</rule>
-		<rule id="ALAS_INCORRECT_USAGE" name="Incorrect Usage for 'alas'">
+		<rule id="ALAS_INCORRECT_USAGE" name="Maling paggamit ng 'alas' (alas-una)">
 			<pattern case_sensitive="no">
 				<token>alas</token>
 				<token>-</token>
 				<token regexp="yes">una|1</token>
 			</pattern>
-  			<message>Did you mean to use <suggestion>ala-\3</suggestion>?</message>
+  			<message>Did you mean to use <suggestion>ala-una</suggestion>?</message>
 			<short>Use ala-una instead of alas-una.</short>
 			<example correction="ala-una" type="incorrect"><marker>alas-una</marker></example>
 			<example correction="ala-1" type="incorrect"><marker>alas-1</marker></example>
 			<example type="correct"><marker>ala-una</marker></example>
-			<example type="correct"><marker>ala-1</marker></example>
+		</rule>
+		<rule id="ALA_INCORRECT_USAGE_NO_GITLING" name="Maling paggamit ng 'ala' (ala (dos->dose))">
+			<pattern case_sensitive="no">
+				<token>ala</token>
+				<token regexp="yes">(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
+			</pattern>
+  			<message>Nais mo bang gamitin ang <suggestion>alas-\2</suggestion>?</message>
+			<short>Gamitin ang alas-(2-12 / dos-dose) imbes na ala-(2-12 / dos-dose).</short>
+			<example correction="alas-dos" type="incorrect"><marker>ala dos</marker></example>
+			<example correction="alas-2" type="incorrect"><marker>ala 2</marker></example>
+			<example type="correct"><marker>alas-dos</marker></example>
+			<example type="correct"><marker>alas-2</marker></example>
+		</rule>
+		<rule id="ALAS_INCORRECT_USAGE_NO_GITLING" name="Maling paggamit ng 'alas' (alas (una|1))">
+			<pattern case_sensitive="no">
+				<token>alas</token>
+				<token regexp="yes">una|1</token>
+			</pattern>
+  			<message>Nais mo bang gamitin ang <suggestion>ala-una</suggestion>?</message>
+			<short>Gamitin ang ala-una imbes na alas-una.</short>
+			<example correction="ala-una" type="incorrect"><marker>alas una</marker></example>
+			<example correction="ala-1" type="incorrect"><marker>alas 1</marker></example>
+			<example type="correct"><marker>ala-una</marker></example>
 		</rule>
 		<rule id="FUSED_ALA_UNA" name="Fused 'alauna' or 'ala1'">
 			<pattern case_sensitive="no">
 				<token regexp="yes">ala(una|1)</token>
 			</pattern>
-			<message>Did you mean to add a gitling? Use <suggestion><match no="1" regexp_match="^(ala)(.+)$" regexp_replace="$1-$2"/></suggestion>.</message>			
-			<short>Use ala-una or ala-1 instead of fused forms.</short>
+			<message>Nais mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1" regexp_match="^(ala)(.+)$" regexp_replace="$1-una"/></suggestion>.</message>			
+			<short>Gamitin ang ala-una imbes na alauna.</short>
 			<example correction="ala-una" type="incorrect"><marker>alauna</marker></example>
 			<example correction="ala-1" type="incorrect"><marker>ala1</marker></example>
 			<example type="correct"><marker>ala-una</marker></example>
-			<example type="correct"><marker>ala-1</marker></example>
 		</rule>
 		<rule id="FUSED_ALAS_DOS_TO_DOSE" name="Fused 'alasdos' to 'alasdose'">
 			<pattern case_sensitive="no">
 				<token regexp="yes">alas(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
 			</pattern>
-			<message>Did you mean to add a gitling? Use <suggestion><match no="1" regexp_match="^(alas)(.+)$" regexp_replace="$1-$2"/></suggestion>.</message>			
-			<short>Use alas-(2-12 / dos-dose) instead of fused forms.</short>
+			<message>Nais mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1" regexp_match="^(alas)(.+)$" regexp_replace="$1-$2"/></suggestion>.</message>			
+			<short>Gamitin ang alas-(2-12 / dos-dose) imbes na pagdikitin ang ala at oras mula 2-12.</short>
 			<example correction="alas-dos" type="incorrect"><marker>alasdos</marker></example>
 			<example correction="alas-2" type="incorrect"><marker>alas2</marker></example>
 			<example type="correct"><marker>alas-dos</marker></example>
@@ -99,15 +130,11 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<pattern case_sensitive="no">
 				<token regexp="yes">ala(1[0-2]|[2-9]|dos|tres|kwatro|singko|sais|siete|otso|nwebe|dyes|onse|dose)</token>
 			</pattern>
-			<message>Did you mean <suggestion><match no="1" regexp_match="^(ala)(.+)$" regexp_replace="alas-$2"/></suggestion>?</message>
-			<short>Use alas (not ala) with times 2–12.</short>
-
+			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(ala)(.+)$" regexp_replace="alas-$2"/></suggestion>?</message>
+			<short>Gamitin ang alas (hindi ala) para sa mga oras mula 2–12.</short>
 			<example correction="alas-2" type="incorrect"><marker>ala2</marker></example>
 			<example correction="alas-4" type="incorrect"><marker>ala4</marker></example>
 			<example correction="alas-dos" type="incorrect"><marker>alados</marker></example>
-
-			<example type="correct"><marker>ala-una</marker></example>
-			<example type="correct"><marker>ala-1</marker></example>
 			<example type="correct"><marker>alas-2</marker></example>
 			<example type="correct"><marker>alas-dos</marker></example>
 		</rule>
@@ -115,12 +142,11 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<pattern case_sensitive="no">
 				<token regexp="yes">alas(una|1)</token>
 			</pattern>	
-			<message>Did you mean <suggestion><match no="1" regexp_match="^(alas)(.+)$" regexp_replace="ala-$2"/></suggestion>?</message>
-			<short>Use ala (not alas) with time 1 (una).</short>	
+			<message>Did you mean <suggestion><match no="1" regexp_match="^(alas)(.+)$" regexp_replace="ala-una"/></suggestion>?</message>
+			<short>Use ala (not alas) with una.</short>	
 			<example correction="ala-una" type="incorrect"><marker>alasuna</marker></example>
 			<example correction="ala-1" type="incorrect"><marker>alas1</marker></example>
 			<example type="correct"><marker>ala-una</marker></example>
-			<example type="correct"><marker>ala-1</marker></example>
 		</rule>
     </category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -235,19 +235,6 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>mag-aral</marker></example>
 			<example type="correct"><marker>nag-iisa</marker></example>
 		</rule>
-		<rule id="PAGHIHIWALAY_NG_KATINIG_SA_PATINIG_NOSPACE" name="Paghiwalay ng katinig sa patinig (walang espasyo)">
-			<pattern case_sensitive="no">
-				<token regexp="yes">^(pag|mag|nag|pang)([aeiou].*)$</token>
-			</pattern>
-			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1" regexp_match="^(pag|mag|nag|pang)([aeiou].*)$" regexp_replace="$1-$2"/></suggestion>.</message>
-			<short>Gamitin ang gitling sa salita.</short>
-			<example correction="pag-ibig" type="incorrect"><marker>pagibig</marker></example>
-			<example correction="mag-aral" type="incorrect"><marker>magaral</marker></example>
-			<example correction="nag-iisa" type="incorrect"><marker>nagiisa</marker></example>
-			<example type="correct"><marker>pag-ibig</marker></example>
-			<example type="correct"><marker>mag-aral</marker></example>
-			<example type="correct"><marker>nag-iisa</marker></example>
-		</rule>
 		<rule id="KASUNOD_NG_DE" name="Paggamit ng gitling sa 'de'">
 			<pattern case_sensitive="no">
 				<token>de</token>
@@ -519,7 +506,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="kumpleto" type="incorrect">kumpleto</example>
             <example type="correct">kompanya</example>
         </rule>
-        <rule id="KAPAG_NAGBAGO_ANG_KATINIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso)">
+        <!--<rule id="KAPAG_NAGBAGO_ANG_KATINIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso)">
             <antipattern>
 				<token regexp="yes">(?i)(kuntrobersya)</token>
 			</antipattern>
@@ -531,7 +518,20 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="kuntrata" type="incorrect">kuntrata</example>
             <example correction="munumento" type="incorrect">munumento</example>
             <example type="correct">kontrata</example>
-        </rule>
+        </rule>-->
+		<rule id="KAPAG_NAGBAGO_ANG_KATINIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso) (MMP 7.3)">
+			<pattern case_sensitive="no">
+				<token regexp="yes">\b(kuntrata|kunsumo|munumento)\b</token>
+			</pattern>
+			<message>Dapat manatili ang 'o' sa mga salitang ito. Isaalang-alang ang <suggestion><match no="1" regexp_match="^([km])un(.*)$" regexp_replace="$1on$2"/></suggestion>?</message>
+			<short>Dapat manatili ang 'o' sa salitang ito.</short>
+			<example correction="kontrata">Pirmahan ang <marker>kuntrata</marker>.</example>
+			<example correction="konsumo">Bawasan ang <marker>kunsumo</marker> ng kuryente.</example>
+			<example correction="monumento">Ang <marker>munumento</marker> ay para sa bayani.</example>
+			<example type="correct">kontrata</example>
+			<example type="correct">kung</example>
+			<example type="correct">muna</example>
+		</rule>
 		<rule id="EPEKTO_NG_HULAPI_E_TO_I" name="Pagpalit ng E sa I (Epekto ng Hulapi)">
             <pattern case_sensitive="no">
                 <token regexp="yes">.*e(han|hin|in|an)$</token>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -275,26 +275,26 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 		<rule id="DE_GITLING" name="Paggamit ng gitling sa 'de'">
 			<pattern case_sensitive="no">
 				<token>de</token>
-				<token regexp="yes">[a-zA-Z]</token>
+				<token regexp="yes">^[a-zA-Z].*</token>
 			</pattern>
 			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion>de-<match no="2"/></suggestion>.</message>
 			<short>Gamitin ang gitling pagkatapos ng 'de' kapag sinusundan ito ng salita.</short>
 			<example correction="de lata" type="incorrect"><marker>de lata</marker></example>
 			<example correction="de kalidad" type="incorrect"><marker>de kalidad</marker></example>
 			<example type="correct"><marker>de-lata</marker></example>
-			<example type="correct"><marker>de-kalidad</marker></example>	]
+			<example type="correct"><marker>de-kalidad</marker></example>
 		</rule>
 		<rule id="DI_GITLING" name="Paggamit ng gitling sa 'di'">
 			<pattern case_sensitive="no">
 				<token>di</token>
-				<token regexp="yes">[a-zA-Z]</token>
+				<token regexp="yes">^[a-zA-Z].*</token>
 			</pattern>
-			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion>di-<match no="2"/></suggestion>.</message>
+			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1"/>-<match no="2"/></suggestion>.</message>
 			<short>Gamitin ang gitling pagkatapos ng 'di' kapag sinusundan ito ng salita.</short>
 			<example correction="di kagandahan" type="incorrect"><marker>di kagandahan</marker></example>
 			<example correction="di mahipo" type="incorrect"><marker>di mahipo</marker></example>
 			<example type="correct"><marker>di-kagandahan</marker></example>
-			<example type="correct"><marker>di-mahipo</marker></example>	]
+			<example type="correct"><marker>di-mahipo</marker></example>	
 		</rule>
 	</category>
 	<category id="WASTONG_PAGIKLI_NG_SALITA" name="Pagpapaikli ng mga Salita">
@@ -303,12 +303,66 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 				<token regexp="yes">[a-zA-Z]+</token>
 				<token regexp="yes">yan|yon</token>
 			</pattern>
-			<message>Ibig mo bang gumamit ng kudlit? Gamitin ang <suggestion>'<match no="1"/></suggestion>.</message>
+			<message>Ibig mo bang gumamit ng kudlit? Gamitin ang <suggestion>'<match no="2"/></suggestion>.</message>
 			<short>Gamitin ang kudlit sa pagitan ng salita at 'yan/'yon.</short>
 			<example correction="bahay yan" type="incorrect"><marker>bahay yan</marker></example>
-			<example correction="kapatid yan" type="incorrect"><marker>kapatid yan</marker></example>
+			<example correction="kapatid yan" type="incorrect"><marker>kapatid yon</marker></example>
 			<example type="correct"><marker>bahay 'yan</marker></example>
-			<example type="correct"><marker>kapatid 'yan</marker></example>
+			<example type="correct"><marker>kapatid 'yon</marker></example>
+		</rule>
+		<rule id="MADALAS_NA_MGA_PINAPAIKLI" name="Mga salitang pinaikli">
+			<pattern case_sensitive="no">
+				<token>sya</token>
+			</pattern>
+			<message>Ibig mo bang sabihin, <suggestion>s'ya</suggestion>?</message>
+			<short>Gamitin ang kudlit sa s'ya.</short>
+		</rule>
+	</category>
+	<category id="SALITANG_INUULIT" name="Salitang Inuulit">
+		<rule id="INUUULIT_NA_SALITA" name="Paggamit ng gitling sa inuulit na salita">
+			<pattern case_sensitive="no">
+				<token regexp="yes">[a-zA-Z]+</token>
+				<token regexp="yes">\1</token>
+			</pattern>
+			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion><match no="1"/>-<match no="1"/></suggestion>.</message>
+			<short>Gamitin ang gitling sa pagitan ng inuulit na salita.</short>
+			<example correction="gabi gabi" type="incorrect"><marker>gabi gabi</marker></example>
+			<example correction="araw araw" type="incorrect"><marker>araw araw</marker></example>
+			<example type="correct"><marker>gabi-gabi</marker></example>
+			<example type="correct"><marker>araw-araw</marker></example>
+		</rule>
+	</category>
+	<category id="HULAPI" name="Wastong Pagbaybay ng Salita na may Hulapi">
+		<rule id="O_U_HAN_HIN" name="Pagbaybay ng hulaping -han/-hin">
+			<pattern case_sensitive="no">
+				<token regexp="yes">[a-zA-Z]+</token>
+				<token regexp="yes" spacebefore="no">(han|hin)</token>
+			</pattern>
+			<message>Ibig mo bang sabihin <suggestion><
+		</rule>
+	</category>
+	<category id="SAMPLE_TWO" name="Two Suggestions">
+		<rule id="Two suggestions" name="Rule with two suggestions">
+			<pattern>
+				<token>TEKSTO</token>
+			</pattern>
+			<message>Did you mean <suggestion>testone</suggestion> or <suggestion>testthree</suggestion>?</message>
+			<short>Rule that offers two suggestions.</short>
+			<example correction="testone" type="incorrect"><marker>teksto</marker></example>
+			<example correction="testthree" type="incorrect"><marker>teksto</marker></example>
+			<example type="correct"><marker>testone</marker></example>
+			<example type="correct"><marker>testthree</marker></example>
+		</rule>
+		<rule id="Another two suggestions" name="Another rule with two suggestions">
+			<pattern>
+				<token>TEKSTO</token>
+			</pattern>
+			<message>Did you mean <suggestion>optionone</suggestion> or <suggestion>optiontwo</suggestion>?</message>
+			<short>Another rule that offers two suggestions.</short>
+			<example correction="optionone" type="incorrect"><marker>teksto</marker></example>
+			<example correction="optiontwo" type="incorrect"><marker>teksto</marker></example>
+			<example type="correct"><marker>optionone</marker></example>
+			<example type="correct"><marker>optiontwo</marker></example>
 		</rule>
 	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -149,4 +149,28 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>ala-una</marker></example>
 		</rule>
     </category>
+	<category id="CONSONANT_ALTERNATION" name="Pagpapalit ng D tungo sa R">
+		<rule id="KATINIG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
+			<pattern case_sensitive="no">
+				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[b-df-hj-np-tv-z]$</token>
+				<token>rin</token>
+			</pattern>
+			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> din</suggestion>?</message>
+			<short>Gamitin ang din kung ang sinusundang salita ay nagtatapos sa katinig.</short>
+			<example correction="kumain din" type="incorrect"><marker>kumain rin</marker></example>
+			<example correction="lumakad din" type="incorrect"><marker>lumakad rin</marker></example>
+			<example type="correct"><marker>kumain din</marker></example>
+		</rule>
+		<rule id="PATINIG_DIN" name="Maling paggamit ng 'din' pagkatapos ng patinig">
+			<pattern case_sensitive="no">
+				<token postag_regexp="yes" postag="^V.*" regexp="yes">.*[aeiou]$</token>
+				<token>din</token>
+			</pattern>
+			<message>Ibig mo bang gamitin ang <suggestion><match no="1"/> rin</suggestion>?</message>
+			<short>Gamitin ang rin kung ang sinusundang salita ay nagtatapos sa patinig.</short>
+			<example correction="kumain rin" type="incorrect"><marker>kumain din</marker></example>
+			<example correction="umiyak rin" type="incorrect"><marker>umiyak din</marker></example>
+			<example type="correct"><marker>kumain rin</marker></example>
+		</rule>
+	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -333,8 +333,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
                 <token regexp="yes">kum(panya|pleto|petisyon|binasyon)</token>
             </pattern>
-            <message>Ang salitang ito ay nagmula sa Espanyol, kaya ang tamang baybay ay <suggestion><match no="1" regexp_match="^(kum)(panya|pleto|petisyon|binasyon)$" regexp_replace="kom$2"/></suggestion>.</message>
-            <short>Dapat 'kom-' (hindi 'kum-') ang baybay ng salitang ito.</short>
+            <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(kum)(panya|pleto|petisyon|binasyon)$" regexp_replace="kom$2"/></suggestion>?</message>
+            <short>Dapat 'kom-' (hindi 'kum-') ang baybay ng salitang ito. Isa itong eksepsiyon.</short>
             <example correction="kumpanya">kumpanya</example>
             <example correction="kumpleto">kumpleto</example>
             <example type="correct">kompanya</example>
@@ -344,11 +344,43 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
                 <token regexp="yes">[km]un(?!p|b|f|v).*</token>
             </pattern>
-            <message>Ayon sa tuntunin, ang 'o' ay nagiging 'u' lamang kapag ang 'n' ay nagiging 'm' (bago ang P/B/F/V). Sa kasong ito, dapat manatili ang 'o'. Isaalang-alang ang <suggestion><match no="1" regexp_match="^([km])(un)(.*)$" regexp_replace="$1on$3"/></suggestion>.</message>
+            <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^([km])(un)(.*)$" regexp_replace="$1on$3"/></suggestion>?</message>
             <short>Dapat manatili ang 'o' sa salitang ito.</short>
             <example correction="kuntrata">kuntrata</example>
             <example correction="munumento">munumento</example>
             <example type="correct">kontrata</example>
+        </rule>
+
+		<rule id="	EPEKTO_NG_HULAPI_E_TO_I" name="Pagpalit ng E sa I (Epekto ng Hulapi)">
+            <antipattern>
+                <token regexp="yes">(?i)(basehan|kortehan)</token>
+            </antipattern>
+            <pattern case_sensitive="no">
+                <token regexp="yes">.*e(han|hin|in|an)$</token>
+            </pattern>
+            <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(.*)e(han|hin|in|an)$" regexp_replace="$1i$2"/></suggestion>?</message>
+            <short>Palitan ang 'e' ng 'i' kapag may hulapi.</short>
+            <example correction="kababaihan">Ang <marker>kababaehan</marker> ay para sa lahat.</example>
+            <example correction="balaihin">Siya ay <marker>balaehin</marker> ko.</example>
+            <example correction="onsihan">Ang <marker>onsehan</marker> ay nauwi sa gulo.</example>
+            <example type="correct">kababaihan</example>
+            <example type="correct" anti_example="yes">basehan</example>
+        </rule>
+
+        <rule id="EPEKTO_NG_HULAPI_O_TO_U" name="Pagpalit ng O sa U (Epekto ng Hulapi)">
+            <antipattern>
+                <token regexp="yes">(?i)(bobohan|teleponohan)</token>
+            </antipattern>
+            <pattern case_sensitive="no">
+                <token regexp="yes">.*o(han|hin|in|an)$</token>
+            </pattern>
+            <message>Ibig mo bang sabihin<suggestion><match no="1" regexp_match="^(.*)o(han|hin|in|an)$" regexp_replace="$1u$2"/></suggestion>?</message>
+            <short>Palitan ang 'o' ng 'u' kapag may hulapi.</short>
+            <example correction="biruin">Huwag mo siyang <marker>biroin</marker>.</example>
+            <example correction="kalbuhin">Balak niyang <marker>kalbohin</marker> ang aso.</example>
+            <example correction="takbuhan">Agad niyang <marker>takbohan</marker> ang bata.</example>
+            <example type="correct">biruin</example>
+            <example type="correct" anti_example="yes">bobohan</example>
         </rule>
 	</category>
 	<category id="SAMPLE_TWO" name="Two Suggestions">

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -218,9 +218,43 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct">maaari daw</example>
 			<example type="correct">araw daw</example>
 		</rule> -->
+		<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
+			<pattern case_sensitive="no">
+				<token>(maaari|araw|biray|)</token>
+				<token>rin</token>
+			</pattern>
+			<message>Ibig mo bang sabihin <suggestion><match no="1"/> din</suggestion>? Kapag nagtatapos sa -ra, -ri, -raw, o -ray, huwag gumamit ng "rin".</message>
+			<short>Gamitin ang "din" imbes na "rin".</short>
+			<example correction="maaari din" type="incorrect"><marker>maaari rin</marker></example>
+			<example correction="araw din" type="incorrect"><marker>araw rin</marker></example>
+			<example type="correct"><marker>maaari din</marker></example>
+			<example type="correct"><marker>araw din</marker></example>
+		</rule>
+		<rule id="EXCEPTION_RAW" name="Eksepsiyon sa paggamit ng 'raw' pagkatapos ng -ra, -ri, -raw, o -ray">
+			<pattern case_sensitive="no">
+				<token>(maaari|araw|biray|)</token>
+				<token>raw</token>
+			</pattern>
+			<message>Ibig mo bang sabihin <suggestion><match no="1"/> daw</suggestion>? Kapag nagtatapos sa -ra, -ri, -raw, o -ray, huwag gumamit ng "raw".</message>
+			<short>Gamitin ang "daw" imbes na "raw".</short>
+			<example correction="maaari daw" type="incorrect"><marker>maaari raw</marker></example>
+			<example correction="araw daw" type="incorrect"><marker>araw raw</marker></example>
+			<example type="correct"><marker>maaari daw</marker></example>
+			<example type="correct"><marker>araw daw</marker></example>
+		</rule>
 	</category>
 	<category id="PALITANG_E_I_AT_O_U" name="Palitang E/I at O/U">
-		<rule_id="PALITANG_E_I" name="Palitang E at I">
-			
-
+		<rule_id="PALITANG_E_I" name="Palitang E at I (unang letra)">
+			<pattern case_sensitive="no">
+				<token>(istasyon|iskandalo|istilo)</token>
+			</pattern>
+			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="\bi(.*)" regexp_replace="e$1"></suggestion>?</message>
+		</rule>
+		<rule_id="PALITANG_O_U" name="Palitang O at U (unang letra)">
+			<pattern case_sensitive="no">
+				<token></token>
+			</pattern>
+			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="" regexp_replace=""></suggestion>?</message>
+		</rule>
+	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -194,7 +194,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="umiyak raw" type="incorrect"><marker>umiyak daw</marker></example>
 			<example type="correct"><marker>kumain raw</marker></example>
 		</rule>
-<!--	<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
+		<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
 			<pattern case_sensitive="no">
 				<token regexp="yes">.*(ra|ri|raw|ray)$</token>
 				<token>rin</token>
@@ -217,8 +217,8 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="araw raw" type="incorrect"><marker>araw raw</marker></example>
 			<example type="correct">maaari daw</example>
 			<example type="correct">araw daw</example>
-		</rule> -->
-		<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
+		</rule> 
+	<!--	<rule id="EXCEPTION_RIN" name="Eksepsiyon sa paggamit ng 'rin' pagkatapos ng -ra, -ri, -raw, o -ray">
 			<pattern case_sensitive="no">
 				<token>(maaari|araw|biray|)</token>
 				<token>rin</token>
@@ -241,7 +241,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="araw daw" type="incorrect"><marker>araw raw</marker></example>
 			<example type="correct"><marker>maaari daw</marker></example>
 			<example type="correct"><marker>araw daw</marker></example>
-		</rule>
+		</rule>-->
 	</category>
 	<!--<category id="PALITANG_E_I_AT_O_U" name="Palitang E/I at O/U">
 		<rule_id="PALITANG_E_I" name="Palitang E at I (unang letra)">
@@ -268,11 +268,35 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example correction="pag-ibig" type="incorrect"><marker>pag ibig</marker></example>
 			<example correction="mag-aral" type="incorrect"><marker>mag aral</marker></example>
 			<example correction="nag-iisa" type="incorrect"><marker>nag iisa</marker></example>
-			<example correction="pang-ulo" type="incorrect"><marker>pang ulo</marker></example>
 			<example type="correct"><marker>pag-ibig</marker></example>
 			<example type="correct"><marker>mag-aral</marker></example>
 			<example type="correct"><marker>nag-iisa</marker></example>
-			<example type="correct"><marker>pang-ulo</marker></example>
+		</rule>
+		<rule id="DE_DI_GITLING" name="Paggamit ng gitling sa 'de' at 'di'">
+			<pattern case_sensitive="no">
+				<token>de|di</token>
+				<token regexp="yes">[a-zA-Z]</token>
+			</pattern>
+			<message>Ibig mo bang gumamit ng gitling? Gamitin ang <suggestion>de-<match no="2"/></suggestion>.</message>
+			<short>Gamitin ang gitling pagkatapos ng 'de' kapag sinusundan ito ng salita.</short>
+			<example correction="de-lata" type="incorrect"><marker>de lata</marker></example>
+			<example correction="de-kalidad" type="incorrect"><marker>de kalidad</marker></example>
+			<example type="correct"><marker>de-lata</marker></example>
+			<example type="correct"><marker>de-kalidad</marker></example>	]
+		</rule>
+	</category>
+	<category id="CONTRACTIONS" name="Pagpapaikli ng mga Salita">
+		<rule id="KUDLIT_YAN_YUN_YON" name="Paggamit ng kudlit sa yan/yun/yon">
+			<pattern case_sensitive="no">
+				<token regexp="yes">[a-zA-Z]+</token>
+				<token regexp="yes">yan|yun|yon</token>
+			</pattern>
+			<message>Ibig mo bang gumamit ng kudlit? Gamitin ang <suggestion>'<match no="1"/></suggestion>.</message>
+			<short>Gamitin ang kudlit sa pagitan ng salita at 'yan.</short>
+			<example correction="bahay 'yan" type="incorrect"><marker>bahay yan</marker></example>
+			<example correction="kapatid 'yan" type="incorrect"><marker>kapatid yan</marker></example>
+			<example type="correct"><marker>bahay 'yan</marker></example>
+			<example type="correct"><marker>kapatid 'yan</marker></example>
 		</rule>
 	</category>
 </rules>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -375,10 +375,10 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 				<token>-</token>
 				<token>iba</token>
 			</pattern>
-			<message>Ang wastong baybay ay <suggestion>iba’t iba</suggestion> (walang gitling).</message>
+			<message>Ang wastong baybay ay <suggestion>iba't iba</suggestion> (walang gitling).</message>
 			<short>Walang gitling; ang tamang anyo ay "iba't iba".</short>
-			<example correction="iba’t iba" type="incorrect"><marker>iba't</marker><marker>-</marker><marker>iba</marker></example>
-			<example type="correct">iba’t iba</example>
+			<example correction="iba't iba" type="incorrect"><marker>iba't</marker><marker>-</marker><marker>iba</marker></example>
+			<example type="correct">iba't iba</example>
 		</rule>
 	</category>
 	<category id="WASTONG_PAGGAMIT_NG_KUDLIT" name="Pagpapaikli ng mga Salita">
@@ -437,7 +437,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             </pattern>
             <message>Iwasan ang balbal na ugaling gawing 'i' ang 'e' sa unahan ng salita. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(is)(kandalo|tasyon|tilo)$" regexp_replace="es$2"/></suggestion>.</message>
             <short>Ang tamang baybay ay 'eskandalo', 'estasyon', o 'estilo'.</short>
-            <example correction="eskandalo">Gumawa siyá ng <marker>iskandalo</marker>.</example>
+            <example correction="eskandalo">Gumawa siya ng <marker>iskandalo</marker>.</example>
             <example correction="estasyon">Pumunta sa <marker>istasyon</marker> ng pulis.</example>
             <example correction="estilo">Mag-iba ka ng <marker>istilo</marker>.</example>
             <example type="correct">eskandalo</example>
@@ -506,19 +506,6 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <example correction="kumpleto" type="incorrect">kumpleto</example>
             <example type="correct">kompanya</example>
         </rule>
-        <!--<rule id="KAPAG_NAGBAGO_ANG_KATINIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso)">
-            <antipattern>
-				<token regexp="yes">(?i)(kuntrobersya)</token>
-			</antipattern>
-			<pattern case_sensitive="no">
-                <token regexp="yes">[km]un(?!p|b|f|v).*</token>
-            </pattern>
-            <message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^([km])(un)(.*)$" regexp_replace="$1on$3"/></suggestion>?</message>
-            <short>Dapat manatili ang 'o' sa salitang ito kung 'N' ang kasunod sa orihinal na salita.</short>
-            <example correction="kuntrata" type="incorrect">kuntrata</example>
-            <example correction="munumento" type="incorrect">munumento</example>
-            <example type="correct">kontrata</example>
-        </rule>-->
 		<rule id="KAPAG_NAGBAGO_ANG_KATINIG_EKSEPSIYON" name="Maling pagpalit ng O sa U (ibang kaso) (MMP 7.3)">
 			<pattern case_sensitive="no">
 				<token regexp="yes">\b(kuntrata|kunsumo|munumento)\b</token>

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -149,7 +149,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>ala-una</marker></example>
 		</rule>
     </category>
-	<category id="CONSONANT_ALTERNATION" name="Pagpapalit ng D tungo sa R">
+	<category id="PAGPAPALIT_D_TUNGO_SA_R" name="Pagpapalit ng D tungo sa R">
 		<rule id="KATINIG_RIN" name="Maling paggamit ng 'rin' pagkatapos ng katinig">
 			<pattern case_sensitive="no">
 			<token regexp="yes">.*[bdfghjklmnpqrstvxz]$</token>
@@ -271,18 +271,17 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<example type="correct"><marker>araw-araw</marker></example>
 		</rule>
 	</category>
-	<category id="WASTONG_PAGIKLI_NG_SALITA" name="Pagpapaikli ng mga Salita">
+	<category id="WASTONG_PAGGAMIT_NG_KUDLIT" name="Pagpapaikli ng mga Salita">
 		<rule id="KUDLIT_YAN_YON" name="Paggamit ng kudlit sa yan/yon">
 			<pattern case_sensitive="no">
-				<token regexp="yes">[a-zA-Z]+</token>
 				<token regexp="yes">yan|yon</token>
 			</pattern>
 			<message>Ibig mo bang gumamit ng kudlit? Gamitin ang <suggestion>'<match no="2"/></suggestion>.</message>
 			<short>Gamitin ang kudlit sa pagitan ng salita at 'yan/'yon.</short>
-			<example correction="bahay yan" type="incorrect"><marker>bahay yan</marker></example>
-			<example correction="kapatid yan" type="incorrect"><marker>kapatid yon</marker></example>
-			<example type="correct"><marker>bahay 'yan</marker></example>
-			<example type="correct"><marker>kapatid 'yon</marker></example>
+			<example correction="yan" type="incorrect"><marker>yan</marker></example>
+			<example correction="yan" type="incorrect"><marker>yon</marker></example>
+			<example type="correct"><marker>'yan</marker></example>
+			<example type="correct"><marker>'yon</marker></example>
 		</rule>
 		<rule id="MADALAS_NA_MGA_PINAPAIKLI" name="Mga salitang pinaikli">
 			<pattern case_sensitive="no">
@@ -297,20 +296,60 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<antipattern>
 				<token regexp="yes">(?i)(kompanya|kompleto|kompetisyon|kompromiso|kompanyon)</token>
 			</antipattern>
-		
+
 			<pattern case_sensitive="no">
 				<token regexp="yes">(con|kon|kom)[pf].*</token>
 			</pattern>
 			
-			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(con|kon|kom)[pf](.*)$" regexp_replace="kump$2"/></suggestion>?</message>
+			<message>Ibig mo bang sabihin, <suggestion><match no="1" regexp_match="^(con|kon|kom)[pf](.*)$" regexp_replace="kump$2"/></suggestion>?</message>
 			<short>Palitan ng 'kump-' (ang F ay nagiging P).</short>
+			
 			<example correction="conferencia">conferencia</example>
 			<example correction="komportable">komportable</example>
-			<example correction="kumpleto">kumpleto</example>
+			<example correction="confortable">confortable</example>
 			
-			<example type="correct">kompanya</example>
-			<example type="correct">kompleto</example>
+			<example type="correct" anti_example="yes">kompanya</example>
+			<example type="correct" anti_example="yes">kompleto</example>
 		</rule>
+		<rule id="KAPAG_NAGBAGO_ANG_PANTIG_KUMB" name="Palitang O/U (con/kon/kom -> kumb)">
+			<antipattern>
+				<token regexp="yes">(?i)(kombinasyon|kombat)</token>
+			</antipattern>
+
+			<pattern case_sensitive="no">
+				<token regexp="yes">(con|kon|kom)[bv].*</token>
+			</pattern>
+			
+			<message>Ibig mo bang sabihin <suggestion><match no="1" regexp_match="^(con|kon|kom)[bv](.*)$" regexp_replace="kumb$2"/></suggestion>?</message>
+			<short>Palitan ng 'kumb-' (ang V ay nagiging B).</short>
+			
+			<example correction="kombensiyon">kombensiyon</example>
+			
+			<example type="correct" anti_example="yes">kombinasyon</example>
+			<example type="correct" anti_example="yes">kombat</example>
+		</rule>
+
+        <rule id="KAPAG_NAGBAGO_ANG_PANTIG_ESPANYOL_EKSEPSIYON" name="Palitang O/U (mga eksepsiyon, kum -> kom)">
+            <pattern case_sensitive="no">
+                <token regexp="yes">kum(panya|pleto|petisyon|binasyon)</token>
+            </pattern>
+            <message>Ang salitang ito ay nagmula sa Espanyol, kaya ang tamang baybay ay <suggestion><match no="1" regexp_match="^(kum)(panya|pleto|petisyon|binasyon)$" regexp_replace="kom$2"/></suggestion>.</message>
+            <short>Dapat 'kom-' (hindi 'kum-') ang baybay ng salitang ito.</short>
+            <example correction="kumpanya">kumpanya</example>
+            <example correction="kumpleto">kumpleto</example>
+            <example type="correct">kompanya</example>
+        </rule>
+
+        <rule id="KAPAG_NAGBAGO_ANG_PANTIG_EXCEPTION" name="Maling pagpalit ng O sa U (ibang kaso)">
+            <pattern case_sensitive="no">
+                <token regexp="yes">[km]un(?!p|b|f|v).*</token>
+            </pattern>
+            <message>Ayon sa tuntunin, ang 'o' ay nagiging 'u' lamang kapag ang 'n' ay nagiging 'm' (bago ang P/B/F/V). Sa kasong ito, dapat manatili ang 'o'. Isaalang-alang ang <suggestion><match no="1" regexp_match="^([km])(un)(.*)$" regexp_replace="$1on$3"/></suggestion>.</message>
+            <short>Dapat manatili ang 'o' sa salitang ito.</short>
+            <example correction="kuntrata">kuntrata</example>
+            <example correction="munumento">munumento</example>
+            <example type="correct">kontrata</example>
+        </rule>
 	</category>
 	<category id="SAMPLE_TWO" name="Two Suggestions">
 		<rule id="Two suggestions" name="Rule with two suggestions">

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/rules/tl/grammar.xml
@@ -27,7 +27,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(benepisio)\b</token>
 			</pattern>
-            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'io' ay nagiging 'yo' sa salitang ito. Isaalang-alang ang <suggestion>benepisyo</suggestion>.</message>
+            <message>Ang 'io' ay nagiging 'yo' sa salitang ito. Isaalang-alang ang <suggestion>benepisyo</suggestion>.</message>
             <short>Palitan ng 'yo' (benepisyo).</short>
             <example correction="benepisyo">Malaki ang <marker>benepisio</marker> nito.</example>
         </rule>
@@ -35,7 +35,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(indibidual)\b</token>
 			</pattern>
-            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ua' ay nagiging 'wa' sa salitang ito. Isaalang-alang ang <suggestion>indibidwal</suggestion>.</message>
+            <message>Ang 'ua' ay nagiging 'wa' sa salitang ito. Isaalang-alang ang <suggestion>indibidwal</suggestion>.</message>
             <short>Palitan ng 'wa' (indibidwal).</short>
             <example correction="indibidwal">Isang <marker>indibidual</marker> ang lumapit.</example>
         </rule>
@@ -43,7 +43,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(perwisio)\b</token>
 			</pattern>
-            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'io' ay nagiging 'yo' sa salitang ito. Isaalang-alang ang <suggestion>perwisyo</suggestion>.</message>
+            <message>Ang 'io' ay nagiging 'yo' sa salitang ito. Isaalang-alang ang <suggestion>perwisyo</suggestion>.</message>
             <short>Palitan ng 'yo' (perwisyo).</short>
             <example correction="perwisyo">Nagdulot ng <marker>perwisio</marker>.</example>
         </rule>
@@ -51,7 +51,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(kompaniya|kompania)\b</token>
 			</pattern>
-            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ia' ay nagiging 'ya' sa salitang ito. Isaalang-alang ang <suggestion>kompanya</suggestion>.</message>
+            <message>Ang 'ia' ay nagiging 'ya' sa salitang ito. Isaalang-alang ang <suggestion>kompanya</suggestion>.</message>
             <short>Palitan ng 'ya' (kompanya).</short>
             <example correction="kompanya">Ang <marker>kompania</marker> ay nagsara.</example>
         </rule>
@@ -59,7 +59,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(teniente)\b</token>
 			</pattern>
-            <message>Ayon sa pangkalahatang tuntunin ng KWF, ang 'ie' ay nagiging 'ye' sa salitang ito. Isaalang-alang ang <suggestion>tenyente</suggestion>.</message>
+            <message>Ang 'ie' ay nagiging 'ye' sa salitang ito. Isaalang-alang ang <suggestion>tenyente</suggestion>.</message>
             <short>Palitan ng 'ye' (tenyente).</short>
             <example correction="tenyente">Si <marker>teniente</marker> ay dumating.</example>
         </rule>
@@ -67,23 +67,23 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(kwento|kuento)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ue' sa unang pantig ay nagiging 'uwe'. Ang tamang baybay ay <suggestion>kuwento</suggestion>.</message>
-            <short>Ang 'cuento' o 'kuento' ay dapat 'kuwento'.</short>
+            <message>Ang kambal-patinig na 'ue' sa unang pantig ay nagiging 'uwe'. Ang tamang baybay ay <suggestion>kuwento</suggestion>.</message>
+            <short>Ang 'kwento' o 'kuento' ay dapat 'kuwento'.</short>
             <example correction="kuwento">Nagbasa siyá ng <marker>kuento</marker>.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_PUWERSA" name="Kataliwasan 5.1: puwersa">
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(pwersa|puersa)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ue' ay nagiging 'uwe' at ang 'f' ay nagiging 'p'. Ang tamang baybay ay <suggestion>puwersa</suggestion>.</message>
-            <short>Ang 'fuerza' o 'puersa' ay dapat 'puwersa'.</short>
+            <message>Ang kambal-patinig na 'ue' ay nagiging 'uwe' at ang 'f' ay nagiging 'p'. Ang tamang baybay ay <suggestion>puwersa</suggestion>.</message>
+            <short>Ang 'pwersa' o 'puersa' ay dapat 'puwersa'.</short>
             <example correction="puwersa">Ginamit niya ang <marker>fuerza</marker>.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_PIYANO" name="Kataliwasan 5.1: piyano">
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(piano|pyano)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ia' sa unang pantig ay nagiging 'iya'. Ang tamang baybay ay <suggestion>piyano</suggestion>.</message>
+            <message>Ang kambal-patinig na 'ia' sa unang pantig ay nagiging 'iya'. Ang tamang baybay ay <suggestion>piyano</suggestion>.</message>
             <short>Ang 'piano' ay dapat 'piyano'.</short>
             <example correction="piyano">Tumugtog siya ng <marker>piano</marker>.</example>
         </rule>
@@ -91,23 +91,23 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(pyesa|piesa)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'ie' ay nagiging 'iye' at ang 'z' ay nagiging 's'. Ang tamang baybay ay <suggestion>piyesa</suggestion>.</message>
-            <short>Ang 'pieza' o 'piesa' ay dapat 'piyesa'.</short>
+            <message>Ang kambal-patinig na 'ie' ay nagiging 'iye' at ang 'z' ay nagiging 's'. Ang tamang baybay ay <suggestion>piyesa</suggestion>.</message>
+            <short>Ang 'pyesa' o 'piesa' ay dapat 'piyesa'.</short>
             <example correction="piyesa">Ito ang kulang na <marker>piesa</marker>.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_BIYUDA" name="Kataliwasan 5.1: biyuda">
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(byuda|biuda)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.1), ang kambal-patinig na 'iu' ay nagiging 'iyu' at ang 'v' ay nagiging 'b'. Ang tamang baybay ay <suggestion>biyuda</suggestion>.</message>
-            <short>Ang 'viuda' o 'biuda' ay dapat 'biyuda'.</short>
+            <message>Ang kambal-patinig na 'iu' ay nagiging 'iyu' at ang 'v' ay nagiging 'b'. Ang tamang baybay ay <suggestion>biyuda</suggestion>.</message>
+            <short>Ang 'byuda' o 'biuda' ay dapat 'biyuda'.</short>
             <example correction="biyuda">Isang <marker>biuda</marker> si Aling Nena.</example>
         </rule>
         <rule id="FIL_KAMBAL_PATINIG_LEKSIYON" name="Kataliwasan 5.2: leksiyon">
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(leksyon|leksion)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>leksiyon</suggestion>.</message>
+            <message>Kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>leksiyon</suggestion>.</message>
             <short>Panatilihin ang patinig (leksiyon).</short>
             <example correction="leksiyon">Tapos na ang <marker>leksyon</marker>.</example>
         </rule>
@@ -115,7 +115,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<pattern case_sensitive="no">
 				<token regexp="yes">\b(kontrobersia|kontrobersya|kuntrobersya)\b</token>
 			</pattern>
-			<message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>kontrobersiya</suggestion>.</message>
+			<message>Kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>kontrobersiya</suggestion>.</message>
 			<short>Panatilihin ang patinig (kontrobersiya).</short>
 			<example correction="kontrobersiya">Maraming <marker>controbersia</marker> tungkol dito.</example>
         </rule>
@@ -123,7 +123,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(lenggwahe)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.2), kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>lengguwahe</suggestion>.</message>
+            <message>Kapag ang kambal-patinig ay sumusunod sa kumpol-katinig, pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>lengguwahe</suggestion>.</message>
             <short>Panatilihin ang patinig (lengguwahe).</short>
             <example correction="lengguwahe">Iba ang <marker>lenggwahe</marker> nila.</example>
         </rule>
@@ -131,7 +131,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(kolehyo|kolehio)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.3), kapag ang kambal-patinig ay sumusunod sa 'h', pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>kolehiyo</suggestion>.</message>
+            <message>Kapag ang kambal-patinig ay sumusunod sa 'h', pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>kolehiyo</suggestion>.</message>
             <short>Panatilihin ang patinig (kolehiyo).</short>
             <example correction="kolehiyo">Nasa <marker>kolehyo</marker> na siya.</example>
         </rule>
@@ -139,7 +139,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
             <pattern case_sensitive="no">
 				<token regexp="yes">\b(rehyon|rehion)\b</token>
 			</pattern>
-            <message>Ayon sa KWF Manwal (5.3), kapag ang kambal-patinig ay sumusunod sa 'h', pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>rehiyon</suggestion>.</message>
+            <message>Kapag ang kambal-patinig ay sumusunod sa 'h', pinapanatili ang unang patinig. Ang tamang baybay ay <suggestion>rehiyon</suggestion>.</message>
             <short>Panatilihin ang patinig (rehiyon).</short>
             <example correction="rehiyon">Saang <marker>rehyon</marker> iyon?</example>
         </rule>
@@ -363,7 +363,7 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 			<pattern case_sensitive="no">
                 <token regexp="yes">(alas-1|alas1|ala-1|ala1|alas-una|alasuna|ala-uno|alauna|alauno)</token>
             </pattern>
-            <message>Tandaan: Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
+            <message>Laging binabaybay ang oras na "ala-una".</message>
             <suggestion>ala-una</suggestion>
             <short>Laging 'ala-una' ang baybay.</short>
             <example correction="alas-1" type="incorrect">alas-1</example>
@@ -376,20 +376,22 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 				<token>ala</token>
 				<token>una</token>
 			</pattern>
-			<message>Ayon sa tuntunin, laging binabaybay ang oras na "ala-una".</message>
+			<message>Laging binabaybay ang oras na "ala-una".</message>
 			<suggestion>ala-una</suggestion>
 			<short>Laging 'ala-una' ang baybay.</short>
 			<example correction="ala-una" type="incorrect">ala una</example>
 			<example type="correct">ala-una</example>
 		</rule>
-		<rule id="WALANG_GITLING_SA_IBA_T_IBA" name="Walang gitling sa iba't iba">
+		<rule id="WALANG_GITLING_SA_IBAT_IBA" name="Walang gitling sa iba't iba (MMP 11.1)">
 			<pattern case_sensitive="no">
-				<token regexp="yes">iba't-iba</token>
+				<token regexp="yes">iba't</token>
+				<token>-</token>
+				<token>iba</token>
 			</pattern>
-			<message>Ang wastong baybay ay <suggestion>iba't iba</suggestion> (walang gitling).</message>
-			<short>Walang gitling sa pagitan ng iba't iba.</short>
-			<example correction="iba't iba" type="incorrect"><marker>iba't-iba</marker></example>
-			<example type="correct"><marker>iba't iba</marker></example>
+			<message>Ang wastong baybay ay <suggestion>iba’t iba</suggestion> (walang gitling).</message>
+			<short>Walang gitling; ang tamang anyo ay "iba't iba".</short>
+			<example correction="iba’t iba" type="incorrect"><marker>iba't</marker><marker>-</marker><marker>iba</marker></example>
+			<example type="correct">iba’t iba</example>
 		</rule>
 	</category>
 	<category id="WASTONG_PAGGAMIT_NG_KUDLIT" name="Pagpapaikli ng mga Salita">
@@ -442,6 +444,44 @@ See tagset.txt for the different POS, Lexical Categories, and corresponding attr
 		</rule>
 	</category>
 	<category id="PALITANG E/I AT O/U" name="Palitang E/I at O/U">
+		<rule id="DISIPLINA_SA_PAGBIGKAS_NG_E_I_IS" name="Disiplina sa E/I">
+            <pattern case_sensitive="no">
+                <token regexp="yes">\b(iskandalo|istasyon|istilo)\b</token>
+            </pattern>
+            <message>Iwasan ang balbal na ugaling gawing 'i' ang 'e' sa unahan ng salita. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(is)(kandalo|tasyon|tilo)$" regexp_replace="es$2"/></suggestion>.</message>
+            <short>Ang tamang baybay ay 'eskandalo', 'estasyon', o 'estilo'.</short>
+            <example correction="eskandalo">Gumawa siyá ng <marker>iskandalo</marker>.</example>
+            <example correction="estasyon">Pumunta sa <marker>istasyon</marker> ng pulis.</example>
+            <example correction="estilo">Mag-iba ka ng <marker>istilo</marker>.</example>
+            <example type="correct">eskandalo</example>
+            <example type="correct">estasyon</example>
+        </rule>
+        <rule id="DISIPLINA_SA_PAGBIGKAS_NG_E_I_IBANG_SALITA" name="Disiplina sa E/I (ibang salita)">
+            <pattern case_sensitive="no">
+                <token regexp="yes">\b(minudo|liyon|nigatibo)\b</token>
+            </pattern>
+            <message>Iwasan ang balbal na ugaling gawing 'i' ang 'e' sa unahan ng salita. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w)i(\w*)$" regexp_replace="$1e$2"/></suggestion>.</message>
+            <short>Ang tamang baybay ay 'menudo', 'leon', o 'negatibo'.</short>
+            <example correction="menudo">Magluto ka ng <marker>minudo</marker>.</example>
+            <example correction="leon">Mukhang <marker>liyon</marker> ang aso.</example>
+            <example correction="negatibo">Laging <marker>nigatibo</marker> ang sagot niya.</example>
+            <example type="correct">menudo</example>
+        </rule>
+        <rule id="DISIPLINA_SA_PAGBIGKAS_NG_O_U" name="Disiplina sa O/U">
+            <pattern case_sensitive="no">
+                <token regexp="yes">\b(kuryente|Kuryano|dunasyon|murado|sumbrero|pulitika)\b</token>
+            </pattern>
+            <message>Iwasan ang balbal na ugaling gawing 'u' ang 'o' sa unahan ng salita. Isaalang-alang ang <suggestion><match no="1" regexp_match="^(\w)u(\w*)$" regexp_replace="$1o$2"/></suggestion>.</message>
+            <short>Ang tamang baybay ay 'koryente', 'Koreano', 'donasyon', 'morado', 'kompanya', 'sombrero', o 'politika'.</short>
+            <example correction="koryente">Nawalan ng <marker>kuryente</marker>.</example>
+            <example correction="Koreano">Isang <marker>Kuryano</marker> ang kumanta.</example>
+            <example correction="donasyon">Nakatanggap ng <marker>dunasyon</marker>.</example>
+            <example correction="morado">Kulay <marker>murado</marker> ang damit.</example>
+            <example correction="sombrero">Magsuot ka ng <marker>sumbrero</marker>.</example>
+            <example correction="politika">Ayaw niya sa <marker>pulitika</marker>.</example>
+            <example type="correct">koryente</example>
+            <example type="correct">kompanya</example>
+        </rule>
 		<rule id="KAPAG_NAGBAGO_ANG_KATINIG_KUMP" name="Palitang O/U (con/kon/kom -> kump)">
 			<antipattern>
 				<token regexp="yes">(?i)(kompanya|kompleto|kompetisyon|kompromiso|kompanyon)</token>


### PR DESCRIPTION
# THS-ST2 compliant rules (Hyphenation, Vowel Alternation, Reduplication, Contractions)

## Description

For THS-ST2, we add a comprehensive set of spelling rules for **Filipino**, aligned with the official guidelines from the *Komisyon sa Wikang Filipino* (KWF), specifically the **_Manwal sa Masinop na Pagsulat_ (MMP)** and **_Ortograpiyang Pambansa_ (OP)**.

## Summary of Changes

### 1. Proper Hyphenation (*Wastong Paggamit ng Gitling*)
* **Examples:**
    * `ika 8` → `ika-8`
    * `alas tres` → `alas-tres`
    * `pag ibig` → `pag-ibig`

### 2. Consonant/Vowel Alternation (*Palitang E/I at O/U*, *D/R*)
* **Examples:**
    * `kumain rin` → `kumain din` (consonant ending)
    * `biroin` → `biruin` 
    * `kabuuan` → `kabuoan` (correction for "double O" rule)

### 3. Reduplication (*Inuulit na Salita*)
* **Examples:**
    * `araw araw` → `araw-araw`
    * `arawaraw` → `araw-araw`
    * `ano ano` → `ano-ano`

### 4. Contractions (*Pagpapaikli ng mga Salita*)
* **Examples:**
    * `sya` → `s'ya`
    * `yan` → `'yan`
    * `ano kamo` → `ano 'ka mo`

### 5. Diphthongs (*Kasong Kambal-Patinig*)
* **Examples:**
    * `benepisio` → `benepisyo`
    * `kuento` → `kuwento`
    * `leksyon` → `leksiyon`